### PR TITLE
DataGrid articles - Replace XF namespaces and update xmlns references

### DIFF
--- a/controls/datagrid/columns/column-types/picker-column.md
+++ b/controls/datagrid/columns/column-types/picker-column.md
@@ -24,7 +24,7 @@ Here are the specific properties defined for `DataGridPickerColumn`:
 * `CellContentFormat`&mdash;Defines the custom format for each cell value. The `String.Format` routine is used and the format passed has to be in the form required by this method.
 * `CellContentTemplate` (`DataTemplate`)&mdash;Defines the appearance of each cell associated with the concrete column. `CellContenTemplate` enables you to customize the default look of the cell.
 * `CellEditTemplate` (`DataTemplate`)&mdash;Defines the editor associated with the concrete column. The `CellEditTemplate` is displayed when the cell is in edit mode.
-* `FilterControlTemplate`(`DataTemplate`)&mdash;Specifies the user defined template used for the Filtering UI. The template must contain an instance of the `Telerik.XamarinForms.DataGrid.DataGridFilterControlBase` class.
+* `FilterControlTemplate`(`DataTemplate`)&mdash;Specifies the user defined template used for the Filtering UI. The template must contain an instance of the `Telerik.Maui.Controls.Compatibility.DataGrid.DataGridFilterControlBase` class.
 * `FooterText`&mdash;Defines the content that will be displayed in the Footer UI that represents the column.
 * `FooterStyle` (`DataGridColumnFooterStyle`)&mdash;Defines the `Style` object that sets the appearance of each footer cell associated with this column.
 * `FooterContentTemplate` (`DataTemplate`)&mdash;Defines the appearance of the footer.

--- a/controls/datagrid/columns/nested-properties.md
+++ b/controls/datagrid/columns/nested-properties.md
@@ -31,7 +31,7 @@ Here is an example how you could utilize the nested properties feature in DataGr
 In the sample both classes inherit from NotifyPropertyChangedBase class which basically implements the INotifyPropertyChanged interface. You would need to add the following namespace to use it:
 
  ```C#
-using Telerik.XamarinForms.Common;
+using Telerik.Maui.Controls.Compatibility.Common;
  ```
 
 1. Create a ViewModel with a collection of `Person` objects:

--- a/controls/datagrid/columns/resizing.md
+++ b/controls/datagrid/columns/resizing.md
@@ -20,7 +20,7 @@ On WinUI and MacOS you can change the column width by positioning the mouse over
 
 To resize a column programatically, you can use the columns `Width` property. For more details review the [Columns Width]({%slug datagrid-columns-width%}) article.
 
-In addition, you can set a `MinimumWidth`(`double`) to the column. This property is applicable when setting `SizeMode` column property to `Fixed`. When `Minimumwidth` is set, you can not reduce the width of the column to a value lower than the `MinimumWidth`. 
+In addition, you can set a `MinimumWidth`(`double`) to the column. This property is applicable when setting `SizeMode` column property to `Fixed`. When `MinimumWidth` is set, you can not reduce the width of the column to a value lower than the `MinimumWidth`. 
 
 ## Disabling Resizing
 

--- a/controls/datagrid/columns/width.md
+++ b/controls/datagrid/columns/width.md
@@ -16,7 +16,7 @@ This article describes how to set a width to the DataGrid column using the SizeM
   * `Stretch`&mdash;The column is stretched to the available width proportionally to its desired width.
   * `Auto`&mdash;The columns is sized to its desired width. That is the maximum desired width of all associated cells.
 * `Width`(`double`)&mdash;Specifies the fixed width for the column. Applicable when the SizeMode property is set to DataGridColumnSizeMode.Fixed.
-* `MinimumWidth`(`double`)&mdash;Specifies the minimum width of a column. This property is applicable when setting `SizeMode` column property to `Fixed`. When `Minimumwidth` is set, you can not reduce the width of the column to a value lower than the `MinimumWidth`. 
+* `MinimumWidth`(`double`)&mdash;Specifies the minimum width of a column. This property is applicable when setting `SizeMode` column property to `Fixed`. When `MinimumWidth` is set, you can not reduce the width of the column to a value lower than the `MinimumWidth`. 
 
 * `ActualWidth` (double): Gets the actual width of the column.
 

--- a/controls/datagrid/editing.md
+++ b/controls/datagrid/editing.md
@@ -15,7 +15,7 @@ The DataGrid provides a built-in editing functionality, which allows the app use
 
 You need to define the `UserEditMode` property of the DataGrid control to enable the editing feature.
 
-The `UserEditMode` property is of type `Telerik.XamarinForms.DataGrid.DataGridUserEditMode` and accepts the following values:
+The `UserEditMode` property is of type `Telerik.Maui.Controls.Compatibility.DataGrid.DataGridUserEditMode` and accepts the following values:
 
 * (Default) `None`&mdash;Editing is disabled.
 * `Cell`&mdash;Enables the editing option.

--- a/controls/datagrid/filtering.md
+++ b/controls/datagrid/filtering.md
@@ -10,7 +10,6 @@ slug: datagrid-filtering-overview
 
 The DataGrid supports filtering through the UI - [Filtering UI](#filtering-ui) and [programmatic filtering](#programmatic-filtering).
 
-
 ## Filtering UI
 
 > On Mobile (iOS and Android) Filtering UI appears when clicking the options icon (**OptionsButton**, three dots) on each column's header and it allows the user to easily filter data by column values.
@@ -40,7 +39,7 @@ Events related to DistinctValuesFilter:
 
 The Telerik DataGrid allows you to apply filtering to the datagrid column using the FilterControlTemplate property.
 
-* **FilterControlTemplate**(DataTemplate): Specifies the user defined template used for Filtering UI. The template must contain an instance of the Telerik.XamarinForms.DataGrid.DataGridFilterControlBase class
+* **FilterControlTemplate**(DataTemplate): Specifies the user defined template used for Filtering UI. The template must contain an instance of the `Telerik.Maui.Controls.Compatibility.DataGrid.DataGridFilterControlBase` class
 
 ## Programmatic Filtering
 
@@ -48,20 +47,33 @@ Programmatic filtering is achieved by adding different filter descriptors in the
 
 The following descriptor types are supported:
 
-* [TextFilterDescriptor](#text-filter-descriptor)
-* [NumericalFilterDescriptor](#numerical-filter-descriptor)
-* [DateTimeFilterDescriptor](#datetime-filter-descriptor)
-* [TimeSpanFilterDescriptor](#timespan-filter-descriptor)
-* [BooleanFilterDescriptor](#boolean-filter-descriptor)
-* [NestedPropertyTextFilterDescriptor](#nested-property-text-filter-descriptor)
-* [DistinctValuesFilterDescriptor](#distinct-values-filter-descriptor)
-* [CompositeFilterDescriptor](#composite-filter-descriptor)
-* [DelegateFilterDescriptor](#delegate-filter-descriptor)
+- [.NET MAUI DataGrid Filtering](#net-maui-datagrid-filtering)
+  - [Filtering UI](#filtering-ui)
+  - [FilterControl Template](#filtercontrol-template)
+  - [Programmatic Filtering](#programmatic-filtering)
+    - [Text Filter Descriptor](#text-filter-descriptor)
+    - [Numerical Filter Descriptor](#numerical-filter-descriptor)
+    - [DateTime Filter Descriptor](#datetime-filter-descriptor)
+    - [TimeSpan Filter Descriptor](#timespan-filter-descriptor)
+    - [Boolean Filter Descriptor](#boolean-filter-descriptor)
+    - [Nested Property Text Filter Descriptor](#nested-property-text-filter-descriptor)
+    - [Distinct Values Filter Descriptor](#distinct-values-filter-descriptor)
+    - [Composite Filter Descriptor](#composite-filter-descriptor)
+    - [Delegate Filter Descriptor](#delegate-filter-descriptor)
+  - [See Also](#see-also)
 
-All `FilterDescriptors` are located in the `Telerik.XamarinForms.Common.Data` namespace:
+All `FilterDescriptors` are located in the `Telerik.Maui.Controls.Compatibility.Common.Data` namespace.
+
+When using C#, you'll need to add the using statement
 
 ```C#
-using Telerik.XamarinForms.Common.Data;
+using Telerik.Maui.Controls.Compatibility.Common.Data;
+```
+
+Alternatively, if using XAML, they're be resolved through the same `telerik` xmlns:
+
+```XAML
+xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 ```
 
 ### Text Filter Descriptor
@@ -75,12 +87,12 @@ The `TextFilterDescriptor` supports the following properties:
 
 To use `TextFilterDescriptor`, you need to add its instance to the `RadDataGrid.FilterDescriptors` collection and to set its `PropertyName` property to associate it with the property from your custom objects. Then, through the `Operator` and `Value` properties, you need to set the filter condition and the value to compare. You can also use the `IsCaseSensitive` property to determine if the text comparisons will be case-sensitive or not.
 
-<snippet id='datagrid-textfilterdescriptor-xaml'/>
+<!-- <snippet id='datagrid-textfilterdescriptor-xaml'/> -->
 ```XAML
-<telerikCommon:TextFilterDescriptor PropertyName="Country"
-                             Operator="StartsWith"
-                             IsCaseSensitive="False"
-                             Value="En"/>
+<telerik:TextFilterDescriptor PropertyName="Country"
+                              Operator="StartsWith"
+                              IsCaseSensitive="False"
+                              Value="En"/>
 ```
 
 ### Numerical Filter Descriptor
@@ -93,11 +105,11 @@ It exposes the following properties:
 * `Value`&mdash;Gets or sets the value used in the comparisons. This is the right operand of the comparison.
 * `Operator`&mdash;Gets or sets the `NumericalOperator` value that defines the boolean logic behind the left and right operand comparison.
 
-<snippet id='datagrid-numericalfilterdecsriptor-xaml'/>
+<!-- <snippet id='datagrid-numericalfilterdecsriptor-xaml'/> -->
 ```XAML
-<telerikCommon:NumericalFilterDescriptor PropertyName="StadiumCapacity"
-                                  Operator="IsLessThan"
-                                  Value="80000"/>
+<telerik:NumericalFilterDescriptor PropertyName="StadiumCapacity"
+                                   Operator="IsLessThan"
+                                   Value="80000"/>
 ```
 
 ### DateTime Filter Descriptor
@@ -110,11 +122,11 @@ It exposes the following properties:
 * `Value`&mdash;Gets or sets the value used in the comparisons. This is the right operand of the comparison.
 * `Operator`&mdash;Gets or sets the `NumericalOperator` value that defines the boolean logic behind the left and right operand comparison.
 
-<snippet id='datagrid-datetimefilterdescriptor-xaml'/>
+<!-- <snippet id='datagrid-datetimefilterdescriptor-xaml'/> -->
 ```XAML
-<telerikCommon:DateTimeFilterDescriptor PropertyName="Established"
-                                 Operator="IsLessThan"
-                                 Value="1900/01/01"/>
+<telerik:DateTimeFilterDescriptor PropertyName="Established"
+                                  Operator="IsLessThan"
+                                  Value="1900/01/01"/>
 ```
 
 ### TimeSpan Filter Descriptor
@@ -127,11 +139,11 @@ It exposes the following properties:
 * `Value`&mdash;Gets or sets the value used in the comparisons. This is the right operand of the comparison.
 * `Operator`&mdash;Gets or sets the `NumericalOperator` value that defines the boolean logic behind the left and right operand comparison.
 
-<snippet id='datagrid-datetimefilterdescriptor-xaml'/>
+<!-- <snippet id='datagrid-datetimefilterdescriptor-xaml'/> -->
 ```XAML
-<telerikCommon:TimeSpanFilterDescriptor PropertyName="Time"
-                                 Operator="IsLessThan"
-                                 Value="22/11/21"/>
+<telerik:TimeSpanFilterDescriptor PropertyName="Time"
+                                  Operator="IsLessThan"
+                                  Value="22/11/21"/>
 ```
 
 ### Boolean Filter Descriptor
@@ -143,10 +155,10 @@ It exposes the following properties:
 * `PropertyName`&mdash;Gets or sets the name of the property that is used to retrieve the filter value.
 * `Value`&mdash;Gets or sets the value used in the comparisons. This is the right operand of the comparison.
 
-<snippet id='datagrid-booleanfilterdescriptor-xaml'/>
+<!-- <snippet id='datagrid-booleanfilterdescriptor-xaml'/> -->
 ```XAML
-<telerikCommon:BooleanFilterDescriptor PropertyName="IsChampion"
-                                Value="true"/>
+<telerik:BooleanFilterDescriptor PropertyName="IsChampion"
+                                 Value="true"/>
 ```
 
 ### Nested Property Text Filter Descriptor
@@ -160,12 +172,12 @@ It exposes the following properties:
 * `Value`&mdash;Gets or sets the value used in the comparisons. This is the right operand of the comparison.
 * `IsCaseSensitive`&mdash;Gets or sets a value that determines whether the text comparisons will be case-sensitive. The default value is `True`.
 
-<snippet id='datagrid-datetimefilterdescriptor-xaml'/>
+<!-- <snippet id='datagrid-datetimefilterdescriptor-xaml'/> -->
 ```XAML
-<telerikCommon:NestedProprtyTextFilterDescriptor PropertyName="Address"
-                                 Operator="Contains"
-                                 IsCaseSensitive="Falses"
-                                 Value="Barcelona"/>
+<telerik:NestedProprtyTextFilterDescriptor PropertyName="Address"
+                                           Operator="Contains"
+                                           IsCaseSensitive="Falses"
+                                           Value="Barcelona"/>
 ```
 
 ### Distinct Values Filter Descriptor
@@ -177,27 +189,27 @@ It exposes the following properties:
 * `PropertyName`&mdash;Gets or sets the name of the property that is used to retrieve the filter value.
 * `Value`&mdash;Gets or sets the value used in the comparisons. This is the right operand of the comparison.
 
-<snippet id='datagrid-datetimefilterdescriptor-xaml'/>
+<!-- <snippet id='datagrid-datetimefilterdescriptor-xaml'/> -->
 ```XAML
-<telerikCommon:DistinctValuesFilterDescriptor />
+<telerik:DistinctValuesFilterDescriptor PropertyName="Country" Value="Austria" />
 ```
 
 ### Composite Filter Descriptor
 
 The `CompositeFilterDescriptor` represents a special `FilterDescriptorBase` that stores an arbitrary number of other descriptors instances. The logical `AND` or `OR` operator is applied upon all composed filters to determine the result of the `PassesFilter` routine.
 
-<snippet id='datagrid-compositefilterdescriptor-xaml'/>
+<!-- <snippet id='datagrid-compositefilterdescriptor-xaml'/> -->
 ```XAML
-<telerikCommon:CompositeFilterDescriptor Operator="And">
-	<telerikCommon:CompositeFilterDescriptor.Descriptors>
-		<telerikCommon:NumericalFilterDescriptor PropertyName="StadiumCapacity"
-                                          Operator="IsGreaterThan"
-                                          Value="55000"/>
-			<telerikCommon:NumericalFilterDescriptor PropertyName="StadiumCapacity"
-                                              Operator="IsLessThan"
-                                              Value="85000"/>
-	</telerikCommon:CompositeFilterDescriptor.Descriptors>
-</telerikCommon:CompositeFilterDescriptor>
+<telerik:CompositeFilterDescriptor Operator="And">
+	<telerik:CompositeFilterDescriptor.Descriptors>
+		<telerik:NumericalFilterDescriptor PropertyName="StadiumCapacity"
+                                           Operator="IsGreaterThan"
+                                           Value="55000"/>
+			<telerik:NumericalFilterDescriptor PropertyName="StadiumCapacity"
+                                               Operator="IsLessThan"
+                                               Value="85000"/>
+	</telerik:CompositeFilterDescriptor.Descriptors>
+</telerik:CompositeFilterDescriptor>
 ```
 
 ### Delegate Filter Descriptor
@@ -210,27 +222,31 @@ Then, you need to add a `DelegateFilterDescriptor` to the `RadDataGrid.FilterDes
 
 The following example demonstrates the `CustomFilter` implementation:
 
-<snippet id='datagrid-delegatefilterdescriptor-csharp'/>
+<!-- <snippet id='datagrid-delegatefilterdescriptor-csharp'/> -->
 ```C#
-class CustomFilter : IFilter
+class CustomFilter : Telerik.Maui.Controls.Compatibility.Common.Data.IFilter
 {
-	public bool PassesFilter(object item)
- 	{
-		if ((item as Club).StadiumCapacity > 60000 && (item as Club).StadiumCapacity <85000)
+    public bool PassesFilter(object item)
+    {
+        if(item is Club club 
+           && club.StadiumCapacity > 60000 
+           && club.StadiumCapacity < 85000)
         {
-			return true;
+            return true;
         }
         else
         {
-			return false;
+            return false;
         }
-	}
+    }
 }
 ```
 
+> Take notice that `IFilter` is in `Telerik.Maui.Controls.Compatibility.Common.Data` namespace.
+
 Add the `DelegateFilterDescriptor` to the `RadDataGrid` instance:
 
-<snippet id='datagrid-delegatefilterdescriptor-added'/>
+<!-- <snippet id='datagrid-delegatefilterdescriptor-added'/> -->
 ```C#
 dataGrid.FilterDescriptors.Add(new DelegateFilterDescriptor() { Filter = new CustomFilter()});
 ```

--- a/controls/datagrid/grouping.md
+++ b/controls/datagrid/grouping.md
@@ -18,11 +18,17 @@ Programmatic grouping can be done by adding descriptors to the `GroupDescriptors
 * [PropertyGroupDescriptor](#property-group-descriptor)&mdash;Uses a property from the model as a group key.
 * [DelegateGroupDescriptor](#delegate-group-descriptor)&mdash;Creates a custom group key which you can use.
 
-All `GroupDescriptors` are located in the `Telerik.XamarinForms.Common.Data` namespace:
+All `GroupDescriptors` are located in the `telerik` namespace:
 
 ```XAML
- xmlns:telerikCommon="clr-namespace:Telerik.XamarinForms.Common.Data;assembly=Telerik.Maui.Controls.Compatibility"
+ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 ```
+
+or if using C#, add a using statement `Telerik.Maui.Controls.Compatibility.Common.Data`.
+
+```CSHARP
+using Telerik.Maui.Controls.Compatibility.Common.Data;
+``
 
 ### Property Group Descriptor
 
@@ -52,7 +58,7 @@ All that is left is to set is the `ViewModel` as `BindingContext` of the page:
 Apply the `PropertyGroupDescriptor`:
 
 ```C#
-this.dataGrid.GroupDescriptors.Add(new Telerik.XamarinForms.Common.Data.PropertyGroupDescriptor()
+this.dataGrid.GroupDescriptors.Add(new Telerik.Maui.Controls.Compatibility.Common.Data.PropertyGroupDescriptor()
 {
     PropertyName="Department"
 });

--- a/controls/datagrid/grouping/property-group-descriptor.md
+++ b/controls/datagrid/grouping/property-group-descriptor.md
@@ -33,7 +33,7 @@ All that is left is to set is the `ViewModel` as `BindingContext` of the page:
 Apply the `PropertyGroupDescriptor`:
 
 ```C#
-this.dataGrid.GroupDescriptors.Add(new Telerik.XamarinForms.Common.Data.PropertyGroupDescriptor()
+this.dataGrid.GroupDescriptors.Add(new Telerik.Maui.Controls.Compatibility.Common.Data.PropertyGroupDescriptor()
 {
     PropertyName="Department"
 });

--- a/controls/datagrid/selection.md
+++ b/controls/datagrid/selection.md
@@ -18,7 +18,7 @@ The DataGrid supports different selection modes that you can modify through the 
 
 ### SelectionUnit
 
-The `SelectionUnit` property (of type `Telerik.XamarinForms.DataGrid.DataGridSelectionUnit`) allows you to control which `Unit` can be selected:
+The `SelectionUnit` property (of type `Telerik.Maui.Controls.Compatibility.DataGrid.DataGridSelectionUnit`) allows you to control which `Unit` can be selected:
 
 * (Default) `Row`&mdash;The unit to select is a grid row.
 * `Cell`&mdash;The unit to select is a cell within a grid row.
@@ -33,12 +33,12 @@ The example below shows how to set `SelectionUnit` in XAML and code-behind:
 ```
 ```C#
 var dataGrid = new RadDataGrid();
-dataGrid.SelectionUnit = Telerik.XamarinForms.DataGrid.DataGridSelectionUnit.Cell;
+dataGrid.SelectionUnit = Telerik.Maui.Controls.Compatibility.DataGrid.DataGridSelectionUnit.Cell;
 ```
 
 ### SelectionMode
 
-The `SelectionMode` property (of type `Telerik.XamarinForms.DataGrid.DataGridSelectionMode`) provides the following modes:
+The `SelectionMode` property (of type `Telerik.Maui.Controls.Compatibility.DataGrid.DataGridSelectionMode`) provides the following modes:
 
 * (Default) `Single`&mdash;A single unit may be selected.
 * `Multiple`&mdash;Multiple units may be selected.
@@ -52,7 +52,7 @@ The example below shows how to set `SelectionMode` in XAML and code-behind:
 ```
 ```C#
 var dataGrid = new RadDataGrid();
-dataGrid.SelectionMode = Telerik.XamarinForms.DataGrid.DataGridSelectionMode.Multiple;
+dataGrid.SelectionMode = Telerik.Maui.Controls.Compatibility.DataGrid.DataGridSelectionMode.Multiple;
 ```
 
 ### SelectedItem/SelectedItems

--- a/controls/datagrid/sorting.md
+++ b/controls/datagrid/sorting.md
@@ -31,16 +31,15 @@ You can sort the data in a DataGrid by pointing a property from the class that d
 * `SortOrder`&mdash;Gets or sets the order of the sorting (ascending or descending).
 
 ```XAML
-<telerikDataGrid:RadDataGrid.SortDescriptors>
-	<telerikCommon:PropertySortDescriptor PropertyName="Name"/>
-</telerikDataGrid:RadDataGrid.SortDescriptors>
+<telerik:RadDataGrid.SortDescriptors>
+	<telerik:PropertySortDescriptor PropertyName="Name"/>
+</telerik:RadDataGrid.SortDescriptors>
 ```
 
-In the example, the used namespaces are defined like this:
+The `telerik` namespace is defined as:
 
 ```XAML
-xmlns:telerikDataGrid="clr-namespace:Telerik.XamarinForms.DataGrid;assembly=Telerik.Maui.Controls.Compatibility"
-xmlns:telerikCommon="clr-namespace:Telerik.XamarinForms.Common.Data;assembly=Telerik.Maui.Controls.Compatibility"
+xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 ```
 
 ### Delegate Sort Descriptor
@@ -58,7 +57,7 @@ The following example demonstrates a custom `IKeyLookup` implementation.
 
 <snippet id='datagrid-delegatesortdescriptor-ikeylookup'/>
 ```C#
-public class CustomIKeyLookup : IKeyLookup
+public class CustomIKeyLookup : Telerik.Maui.Controls.Compatibility.Common.Data.IKeyLookup
 {
 	public object GetKey(object instance)
 	{


### PR DESCRIPTION
This only reviews the DataGrid pages. I will work on going through all the different article to find any lingering instances of the old xmlns usage and/or Telerik.XamarinForms namespaces.