### PR TITLE
Update SideDrawer Getting Started

### DIFF
--- a/controls/sidedrawer/getting-started.md
+++ b/controls/sidedrawer/getting-started.md
@@ -41,6 +41,42 @@ The SideDrawer control contains two views - `MainContent` and `DrawerContent` Th
 xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui" 
  ```
 
+1. Add the DefaultButtonStyle to the VerticalStackLayout's Resources.
+
+```XAML
+<telerik:RadSideDrawer x:Name="drawer" 
+                       DrawerLength="200">
+    <telerik:RadSideDrawer.MainContent>
+        <Grid>
+            <Label Text="Main content" />
+        </Grid>
+    </telerik:RadSideDrawer.MainContent>
+    <telerik:RadSideDrawer.DrawerContent>
+        <VerticalStackLayout Spacing="10"
+                             Padding="10, 10, 0, 0">
+            <VerticalStackLayout.Resources>
+	        <!-- A button style for only DrawerContent -->
+                <Style x:Key="DefaultButtonStyle" TargetType="Button">
+                    <Setter Property="WidthRequest" Value="180" />
+                    <Setter Property="HeightRequest" Value="40" />
+                    <Setter Property="BackgroundColor" Value="#b1b1b1" />
+                    <Setter Property="TextColor" Value="Black" />
+                </Style>
+            </VerticalStackLayout.Resources>
+
+            <Button Text="Mail"
+                    Style="{StaticResource DefaultButtonStyle}" />
+            <Button Text="Calendar"
+                    Style="{StaticResource DefaultButtonStyle}" />
+            <Button Text="People"
+                    Style="{StaticResource DefaultButtonStyle}" />
+            <Button Text="Tasks"
+                    Style="{StaticResource DefaultButtonStyle}" />
+        </VerticalStackLayout>
+    </telerik:RadSideDrawer.DrawerContent>
+</telerik:RadSideDrawer>
+```
+
 1. Register the Telerik controls through the `Telerik.Maui.Controls.Compatibility.UseTelerik` extension method called inside the `CreateMauiApp` method of the `MauiProgram.cs` file of your project:
 
  ```C#


### PR DESCRIPTION
The automated code snippet contains references to `DefaultButtonStyle` that is not copied over to the documentation.

## Current Fix
I copied the missing styles to the inner scope so the code example works for now

### Long-term fix
We should come up with a decision on whether or not to include those styles inside the snippet-id, or I highly recommend just using an implicit stye for the page.

Change the SDKExample to the following instead, notice the Style is now implicit to all Buttons, and each Button in the DrawerContent doesn't need a StaticResource

```XAML
<?xml version="1.0" encoding="utf-8" ?>
<telerik:RadContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                        xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
                        x:Class="SDKBrowserMaui.Examples.SideDrawerControl.GettingStartedCategory.GettingStartedExample.SideDrawerGettingStartedXaml">
    <telerik:RadContentView.Resources>
        <ResourceDictionary>
<!-- PROPOSED SOLUTION
In the SDKSamples project, change this to an implicit style. This will allow us to still keep the same appearance, without complicating our Getting Started example
-->
            <Style TargetType="Button">
                <Setter Property="WidthRequest" Value="180" />
                <Setter Property="HeightRequest" Value="40" />
                <Setter Property="BackgroundColor" Value="#b1b1b1" />
                <Setter Property="TextColor" Value="Black" />
            </Style>
        </ResourceDictionary>
    </telerik:RadContentView.Resources>

    <Grid>
        <Grid.RowDefinitions>
            <RowDefinition Height="Auto" />
            <RowDefinition />
        </Grid.RowDefinitions>
        <HorizontalStackLayout Spacing="10">
            <ImageButton WidthRequest="{OnPlatform Default='25', WinUI='32'}" 
                         HeightRequest="{OnPlatform Default='25', WinUI='32'}" 
                         BorderWidth="0" 
                         BorderColor="Transparent" 
                         BackgroundColor="Transparent" 
                         Source="hamburgermenu.png"
                         Clicked="OnButtonClicked"
                         AutomationId="openAndCloseButton">
            </ImageButton>
            <Label VerticalOptions="Center"
                   Text="SideDrawer" />
        </HorizontalStackLayout>
        <Grid Grid.Row="1">
        <!--  >> sidedrawer-gettingstarted-xaml  -->
            <telerik:RadSideDrawer x:Name="drawer" 
                                   DrawerLength="200">
                <telerik:RadSideDrawer.MainContent>
                    <Grid>
                        <Label Text="Main content" />
                    </Grid>
                </telerik:RadSideDrawer.MainContent>
                <telerik:RadSideDrawer.DrawerContent>
                    <VerticalStackLayout Spacing="10"
                                         Padding="10, 10, 0, 0">
<!-- PROPOSED SOLUTION 
The StaticResource has been removed from the Buttons, the style is now applied implicitly
-->
                        <Button Text="Mail"  />
                        <Button Text="Calendar"  />
                        <Button Text="People" />
                        <Button Text="Tasks" />
                    </VerticalStackLayout>
                </telerik:RadSideDrawer.DrawerContent>
            </telerik:RadSideDrawer>
        <!--  << sidedrawer-gettingstarted-xaml  -->
        </Grid>
    </Grid>
</telerik:RadContentView>
```


