### PR TITLE
ComboBox - Update Getting started 

### DIFF
--- a/controls/combobox/getting-started.md
+++ b/controls/combobox/getting-started.md
@@ -18,15 +18,17 @@ At the end, you will be able to achieve the following result.
 
 Before adding the ComboBox, you need to:
 
-1. [Set up your .NET MAUI application]({%slug maui-getting-started %}#set-up-your-net-maui-application).
+1. [Set up your .NET MAUI application]({%slug maui-getting-started %}#step-1-set-up-your-net-maui-application).
 
-1. [Download Telerik UI for .NET MAUI]({% slug maui-getting-started %}#download-telerik-ui-for-net-maui).
+1. [Download Telerik UI for .NET MAUI]({% slug maui-getting-started %}#step-2-download-telerik-ui-for-net-maui).
 
-1. [Install Telerik UI for .NET MAUI]({%slug maui-getting-started %}#install-telerik-ui-for-net-maui).
+1. [Install Telerik UI for .NET MAUI]({%slug maui-getting-started %}#step-3-install-telerik-ui-for-net-maui).
+
+1. [Register Required Handlers and Renderers]({%slug maui-getting-started %}#step-4-register-required-handlers-and-renderers).
 
 ## Define the Control
 
-When your .NET MAUI application is set up, you are ready to add a ComboBox control to your page. The following example demonstrates the definition of the `RadComboBox` with `ItemsSource` set to a static collection as well as bound to property from a ViewModel class.
+When your .NET MAUI application is setup, you are ready to add a ComboBox control to your page. The following example demonstrates the definition of the `RadComboBox` with `ItemsSource` set to a static collection as well as bound to property from a ViewModel class.
 
 ### Using static data
 


### PR DESCRIPTION
1. Fixed outdated slugs in the Prerequisites (jump links didn't work, it only loads the page)
2. Added important missing step in Prerequisites (registering handlers).

Number 2 addresses a set of recent support tickets where the developer didn't add `UseTelerik()` to **MauiProgram.cs**. After reviewing the ComboBox's Getting Started documentation, it is indeed missing.