### PR TITLE
ItemsControl Getting started fixes

### DIFF
--- a/controls/itemscontrol/getting-started.md
+++ b/controls/itemscontrol/getting-started.md
@@ -29,7 +29,7 @@ Before adding the ItemsControl, you need to:
 1. When the your .NET MAUI application is set up, you are ready to add a ItemsControl to your page.
 
  ```XAML
-<telerik:RadItemsControl/>
+<telerik:RadItemsControl x:Name="itemsControl"/>
  ```
 
 1. Add the `telerik` namespace:


### PR DESCRIPTION
The ItemsControl getting started docs were missing the name to the control that is being referenced in the code-behind.