### PR TITLE
Review Chat Docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -126,7 +126,7 @@ navigation:
     ## End Chart
     ## Chat
     controls/chat:
-        title: "Conversational UI(Chat)"
+        title: "Conversational UI (Chat)"
     controls/chat/items:
         title: "Chat Items"
         position: 3

--- a/controls/chat/commands.md
+++ b/controls/chat/commands.md
@@ -31,3 +31,4 @@ Here is an example on how to define a command in the ViewModel and bind the `Sen
 ## See Also
 
 - [MVVM Support]({% slug chat-mvvm-support%})
+- [Chat Items]({%slug chat-items-overview %})

--- a/controls/chat/commands.md
+++ b/controls/chat/commands.md
@@ -8,11 +8,11 @@ slug: chat-commands
 
 # .NET MAUI Chat Commands
 
-Telerik UI for .NET MAUI RadChat allows you to attach commands that will be executed when certain actions such as SendMessage occur.
+The Telerik UI for .NET MAUI Chat allows you to attach commands that will be executed when certain actions such as `SendMessage` occur.
 
 ## Chat Commands
 
-Take advantage of the `SendMessageCommand` that is triggered when the send-message button is clicked or when the user presses the **Enter** key (on desktop). The command is raised before the Chat auto-creates a ChatItem and adds it to the Items collection.
+Take advantage of the `SendMessageCommand` that is triggered when the send-message button is clicked or when the user presses the `Enter` key on desktop platforms. The command is raised before the Chat auto-creates a `ChatItem` and adds it to the `Items` collection.
 
 Here is an example on how to define a command in the ViewModel and bind the `SendMessageCommand` to it:
 
@@ -20,7 +20,7 @@ Here is an example on how to define a command in the ViewModel and bind the `Sen
 
 <snippet id='chat-commands-executemethod' />
 
-**2.** Define the RadChat component:
+**2.** Define the `RadChat` component:
 
 <snippet id='chat-commands-xaml' />
 

--- a/controls/chat/getting-started.md
+++ b/controls/chat/getting-started.md
@@ -66,6 +66,9 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 ## Additional Resources
 
 - [MVVM Support]({% slug chat-mvvm-support%})
+- [Commands]({% slug chat-commands %})
+- [Chat Items]({%slug chat-items-overview %})
+- [Suggested Actions]({%slug chat-suggested-actions %})
 
 ## See Also
 

--- a/controls/chat/getting-started.md
+++ b/controls/chat/getting-started.md
@@ -6,13 +6,13 @@ position: 2
 slug: chat-getting-started
 ---
 
-# Getting Started with .NET MAUI Chat
+# Getting Started with the .NET MAUI Chat
 
 This guide provides the information you need to start using the Telerik UI for .NET MAUI Chat by adding the control to your project.
 
-![Chat Getting Started](images/chat-gettingstarted-desktop.png)
+At the end, you will be able to achieve the result on the first image for desktop platforms and the results on the second image for mobile platforms:
 
-And the result on mobile platforms:
+![Chat Getting Started](images/chat-gettingstarted-desktop.png)
 
 ![Chat Getting Started](images/chat-gettingstarted-mobile.png)
 
@@ -28,7 +28,7 @@ Before adding the Chat, you need to:
 
 ## Define the Control
 
-1. When your .NET MAUI application is set up, you are ready to add a RadChat control to your page.
+1. When your .NET MAUI application is set up, you are ready to add a `RadChat` control to your page.
 
  ```XAML
 <telerik:RadChat x:Name="chat"/>
@@ -65,10 +65,11 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 ## Additional Resources
 
-- [Telerik .NET MAUI blogs](https://www.telerik.com/blogs/mobile-net-maui)
-- [Telerik .NET MAUI roadmap](https://www.telerik.com/support/whats-new/maui-ui/roadmap)
-
+- [MVVM Support]({% slug chat-mvvm-support%})
 
 ## See Also
 
-- [MVVM Support]({% slug chat-mvvm-support%})
+- [.NET MAUI Chat Product Page](https://www.telerik.com/maui-ui/chat-(conversational-ui))
+- [.NET MAUI Chat Forum Page](https://www.telerik.com/forums/maui?tagId=2061)
+- [Telerik .NET MAUI Blogs](https://www.telerik.com/blogs/mobile-net-maui)
+- [Telerik .NET MAUI Roadmap](https://www.telerik.com/support/whats-new/maui-ui/roadmap)

--- a/controls/chat/item-template-selector.md
+++ b/controls/chat/item-template-selector.md
@@ -6,11 +6,11 @@ position: 9
 slug: chat-itemtemplate-selector
 ---
 
-# .NET MAUI Chat ItemTemplateSelector
+# .NET MAUI Chat `ItemTemplateSelector`
 
 The `RadChat` control exposes an `ItemTemplateSelector` property which you can use to apply different templates to each Chat item depending on a specific condition.
 
-## Default ItemTemplateSelector
+## Default `ItemTemplateSelector`
 
 Any change in the appearance of the Chat items depends on the `ChatItemTemplateSelector` and the containing templates and referenced styles. The default selector includes separate templates for the incoming and outgoing messages (so they're aligned to the left or right) and for single, first, middle, and last messages (in the case there area a few messages in a row)—this is needed to achieve the "balloon" look & feel of the messages. In addition, the `TimeBreak` template is also assigned through the `ItemTemplateSelector`.
 
@@ -29,7 +29,7 @@ You can apply any changes to the templates and then assign the template selector
 
 <snippet id='chat-features-defaultitemtemplate-xaml' />
 
-## Custom ItemTemplateSelector
+## Custom `ItemTemplateSelector`
 
 You can create a custom `ChatItemTemplateSelector` to conditionally apply different message styles depending on any of the used Chat item properties.
 

--- a/controls/chat/item-template-selector.md
+++ b/controls/chat/item-template-selector.md
@@ -8,55 +8,58 @@ slug: chat-itemtemplate-selector
 
 # .NET MAUI Chat ItemTemplateSelector
 
-`RadChat` control exposes an `ItemTemplateSelector` property which you can use to apply different templates to each chat item depending on a specific condition.
+The `RadChat` control exposes an `ItemTemplateSelector` property which you can use to apply different templates to each Chat item depending on a specific condition.
 
 ## Default ItemTemplateSelector
 
-Any change on the appearance of the chat items depends on the `ChatItemTemplateSelector` and the containing templates and referenced styles. The default selector includes separate templates for the incoming and outgoing messages (so they're aligned on the left/right accordingly), as well as for single, first, middle and last messages (in the case there area a few messages in a row) - this is needed in order to achieve the "balloon" look & feel of the messages. In addition, the `TimeBreak` template is also assigned through the `ItemTemplateSelector`.
+Any change in the appearance of the Chat items depends on the `ChatItemTemplateSelector` and the containing templates and referenced styles. The default selector includes separate templates for the incoming and outgoing messages (so they're aligned to the left or right) and for single, first, middle, and last messages (in the case there area a few messages in a row)—this is needed to achieve the "balloon" look & feel of the messages. In addition, the `TimeBreak` template is also assigned through the `ItemTemplateSelector`.
 
-Below you can find the default `ItemTemplateSelector` which you can use as a base for any further customizations to the way the messages look. 
+Below you can find the default `ItemTemplateSelector`, which you can use as a base for any further customizations to the way the messages look. 
 
-In short, the default templates contain a `RadBorder` control (used to achieve the rounded edges), `Image` control (used for the avatar image only for the single and first messages), and a `Label` for the text message itself. 
+The default templates contain:
+* a `RadBorder` control (used to achieve the rounded edges).
+* an `Image` control (used for the avatar image only for the single and first messages).
+* a `Label` for the text message itself. 
 
 The code snippet below contains the default templates and the accompanying styles:
 
 <snippet id='chat-features-defaultitemtemplate-resources' />
 
-Any changes could be applied to the templates and then assign the template selector to the `ItemTemplateSelector` property of the Chat control:
+You can apply any changes to the templates and then assign the template selector to the `ItemTemplateSelector` property of the Chat control:
 
 <snippet id='chat-features-defaultitemtemplate-xaml' />
 
 ## Custom ItemTemplateSelector
 
-You can create a custom `ChatItemTemplateSelector` to conditionally apply different messages styles depending on any of the used chat item properties.
+You can create a custom `ChatItemTemplateSelector` to conditionally apply different message styles depending on any of the used Chat item properties.
 
-### Example:
+The following example demonstrates how to create a custom `ChatItemTemplateSelector`:
 
-Have the following ChatItem class with a custom MessageCategory property to distinguish important messages:
+**1.** To apply a distinct style to the important messages, add the following `ChatItem` class with a custom `MessageCategory` property: 
 
 <snippet id='chat-features-itemtemplate-chatitem' />
 
-Add a few sample Items to the Chat's ItemsSource:
+**2.** Add a few sample Items to the Chat's `ItemsSource`:
 
 <snippet id='chat-features-itemtemplate-items' />
 
-> You would need to supply an ItemsConverter as you're using custom items as demonstrated inside MVVM Support topic.
+> You need to supply an `ItemsConverter` as you're using custom items as demonstrated inside MVVM Support topic.
 
 <snippet id='chat-features-itemtemplate-itemconverter' />
 
-Create a CustomChatItemTemplateSelector class that derives from the ChatItemTemplateSelector:
+**3.** Create a `CustomChatItemTemplateSelector` class that derives from the `ChatItemTemplateSelector`:
 
 <snippet id='chat-features-itemtemplate-templateselector' />
 	
-Create the needed XAML resources:
+**4.**  Create the needed XAML resources:
 
 <snippet id='chat-features-itemtemplate-resources' />
 
-Set it to the Chat's ItemTemplateSelector property:
+**5.** Set it to the Chat's `ItemTemplateSelector` property:
 
 <snippet id='chat-features-itemtemplate-xaml' />
 
-Here is an example how you could customize the control:
+The image below shows how the customized Chat control could look:
 
 ![Chat Customization](images/chat-customization.png)
 

--- a/controls/chat/items/chat-messages.md
+++ b/controls/chat/items/chat-messages.md
@@ -8,23 +8,23 @@ slug: chat-items-messages
 
 # Chat Messages 
 
-`ChatMessage` is the basic message unit in RadChat. It contains information about the `Author` of the message as well as any additional data regarding the message.
+`ChatMessage` is the basic message unit in `RadChat`. It contains information about the `Author` of the message as well as any additional data about the message.
 
 The Author property is of type `Telerik.Maui.Controls.Chat.Author` and exposes the following properties:
 
 * `Name`&mdash;Author name;
 * `Avatar`&mdash;Image related to the author, displayed in the Chat UI;
-* `Data`&mdash;You could use it to preserve additional information about the author;
+* `Data`&mdash;You can use it to preserve additional information about the author;
 
-By default, when the end user types in the textbox and confirms the message, it is set to the to RadChat's Message property. In addition, the SendMessage event is fired each time a new message is about to be added to the chat UI. It allows to modify the message itself.
+By default, when the end user types in the text box and confirms the message, it is set to the to Chat's `Message` property. In addition, the `SendMessage` event is fired each time a new message is about to be added to the Chat UI. It allows you to modify the message itself.
 
-## TextMessage
+## Text Message
 
-The `TextMessage` is intended to be used for sending a simple string type message. It derives from ChatMessage and provides an additional `Text` property which holds the string message. 
+The `TextMessage` is intended to be used for sending a simple string type message. It derives from `ChatMessage` and provides an additional `Text` property which holds the string message. 
 
-#### Adding a message
+### Adding a message
 
-You could create a sample TextMessage message like this:
+The following example demonstrates how to create a sample `TextMessage`:
 
 ```C#
 var bot = new Author() { Name = "bot", Avatar = "SampleAvatar.png" };

--- a/controls/chat/items/overview.md
+++ b/controls/chat/items/overview.md
@@ -8,19 +8,19 @@ slug: chat-items-overview
 
 # Chat Items 
 
-`RadChat` works with a collection of `ChatItem` objects. The control provides different chat items that you could use, such as the basic `TextMessage` as well as `PickerItems` used to display various pickers (item, date and time picker) and predefined cards (defined through a card picker).
+The `RadChat` control works with a collection of `ChatItem` objects. The control provides different Chat Items that you can use, such as the basic `TextMessage` and the `PickerItems` used to display various pickers (item, date, and time picker) and predefined cards (defined through a card picker).
 
-This section covers the specific details of the different chat items RadChat provides:
+This section covers the specific details of the different Chat Items provided by `RadChat`:
 
-* [Message]({%slug chat-items-messages %}) - the basic message unit in RadChat; apart from the text of the message itself, each `TextMessage` instance contains information about the Author of the message as well as any additional data;
-* [Time Break]({%slug chat-items-timebreak %}) - used to encapsulate messages in a conversation by a certain condition such as read/unread, time intervals or any other you would choose. It is visualizes as a dividing line across the messages board with a text message attached to it.
-* [PickerItem]({%slug chat-picker-overview %}) - special `ChatItem` type which contains RadChatPicker control used for providing a selection to the end user. Depending on the information that is presented and the choice that should be made, the pickers can be one of the types listed below:
-	* `DatePicker`&mdash;For displaying a Calendar to choose a date;
-    * `TimePicker`&mdash;For displaying a clock view to choose a time;
-    * `ItemPicker`&mdash;For presenting a list of suggestions the end user could choose from;
-    * `CardPicker`&mdash;For presenting a list of cards with structured layout;
+* [Message]({%slug chat-items-messages %})—The basic message unit in RadChat; apart from the text of the message itself, each `TextMessage` instance contains information about the Author of the message as well as any additional data.
+* [Time Break]({%slug chat-items-timebreak %})—Used to encapsulate messages in a conversation by a certain condition such as read/unread, time intervals, or any other condition. It visualizes as a dividing line across the messages board with a text message attached to it.
+* [PickerItem]({%slug chat-picker-overview %})—A special `ChatItem` type which contains a `RadChatPicker` control used for providing a selection to the end user. Depending on the information that is presented and the choices the user can make, the pickers can be one of the following types:
+	* `DatePicker`&mdash;Displays a Calendar to choose a date.
+    * `TimePicker`&mdash;Displays a clock view to choose a time.
+    * `ItemPicker`&mdash;Displays a list of suggestions the end user could choose from.
+    * `CardPicker`&mdash;Displays a list of cards with structured layout.
 
-> Additionally, you could create your own chat items with custom item templates and add them to the `Items` collection of the control. For more details go to the [MVVM Support]({% slug chat-mvvm-support %}) and [ItemTemplateSelector]({% slug chat-itemtemplate-selector %}) topics.
+> Additionally, you can create your own Chat Items with custom item templates and add them to the `Items` collection of the control. For more details, see the [MVVM Support]({% slug chat-mvvm-support %}) and [`ItemTemplateSelector`]({% slug chat-itemtemplate-selector %}) topics.
 
 ## See Also
 

--- a/controls/chat/items/timebreak.md
+++ b/controls/chat/items/timebreak.md
@@ -8,13 +8,13 @@ slug: chat-items-timebreak
 
 # Chat Time Break 
 
-`TimeBreak` item of `RadChat` is intended to encapsulate a group of messages according to a certain condition, such as given time intervals or read/unread messages. It is visualized as a dividing line across the messages board with a text message attached to it. 
+The `TimeBreak` item of the `RadChat` control encapsulates a group of messages according to a certain condition, such as given time intervals or read/unread messages. It is visualized as a dividing line across the messages board with a text message attached to it. 
 
-TimeBreak derives from ChatItem and provides an additional `Text` property which holds the string message.
+`TimeBreak` derives from `ChatItem` and provides an additional `Text` property which holds the string message.
 
-#### Adding a TimeBreak
+### Adding a Time Break
 
-You could create a sample TimeBreak item like this:
+The following example shows how to create a sample `TimeBreak` item:
 
 <snippet id='chat-chatitems-timebreak' />
 

--- a/controls/chat/localization.md
+++ b/controls/chat/localization.md
@@ -8,18 +8,18 @@ slug: chat-localization
 
 # .NET MAUI Chat Localization
 
-`RadChat` provides a language localization. In short, you can translate the used across the Chat control phrases to other languages, so that your app can be adapted to different regions.
+The `RadChat` component provides language localization. This allows you to translate the phrases used across the Chat control to other languages so that you can adapt your app to different regions.
 
->important To learn in details about the localization process of Telerik UI for .NET MAUI components, please go through the common [Localization and Globalization]({%slug globalization-localization%}) topic.
+> To learn in details about the localization process of the Telerik UI for .NET MAUI components, see the [Localization and Globalization]({%slug globalization-localization%}) topic.
 
-In RadChat you can localize the following string:
+In `RadChat`, you can localize the following string:
 
 | Localization Key | Default Value |
 | -----------------| ------------- |
 | Chat_EntryPlaceholder | Type a message... | 
 
-The localization key refers to the watermark message that is shown in the input field of the Chat as shown in the image below:
+The localization key refers to the watermark message that appears in the input field of the Chat.
 
 ## See Also
 
-[Localizatiion and Globalization](slug %globalization-localization%)
+[Localization and Globalization](slug %globalization-localization%)

--- a/controls/chat/mvvm-support.md
+++ b/controls/chat/mvvm-support.md
@@ -8,7 +8,7 @@ slug: chat-mvvm-support
 
 # .NET MAUI Chat MVVM Support 
 
-With the `RadChat` control, you can easily utilize the Model-View-ViewModel (MVVM) pattern. You can achieve this through the `ItemsSource` property that can be bound or set to a collection of data items that will be converted into Chat items.
+With the `RadChat` control, you can use the Model-View-ViewModel (MVVM) pattern. You can achieve this through the `ItemsSource` property that can be bound or set to a collection of data items that will be converted into Chat items.
 
 The following example shows how to use `RadChat` in MVVM scenarios.
 

--- a/controls/chat/mvvm-support.md
+++ b/controls/chat/mvvm-support.md
@@ -6,25 +6,25 @@ position: 7
 slug: chat-mvvm-support
 ---
 
-# .NET MAUI RadChat MVVM Support 
+# .NET MAUI Chat MVVM Support 
 
-With the `RadChat` control you can easily utilize the Model-View-ViewModel (MVVM) pattern. This can be achieved through the `ItemsSource` property that can be bound/set to a collection of any data items that should be then converted into chat items.
+With the `RadChat` control, you can easily utilize the Model-View-ViewModel (MVVM) pattern. You can achieve this through the `ItemsSource` property that can be bound or set to a collection of data items that will be converted into Chat items.
 
-This help article will demonstrate how to use `RadChat` in MVVM scenarios.
+The following example shows how to use `RadChat` in MVVM scenarios.
 
-Create a sample class used to hold the needed information for the chat items:
+**1.** Create a sample class used to hold the needed information for the Chat items:
 
 <snippet id='chat-features-mvvm-chatitem'/>
 
-Create a ViewModel containing a collection of your `SimpleChatItem` items. You could also bind the Chat's `Author` property that represents the end user typing in the input field.
+**2.** Create a ViewModel containing a collection of your `SimpleChatItem` items. You can also bind the Chat's `Author` property that represents the end user typing in the input field.
 
 <snippet id='chat-features-mvvm-viewmodel'/>
 
-Create a Converter class of type `IChatItemConverter` in order to convert the data items into chat messages and vice versa:
+**3.** Create a `Converter` class of type `IChatItemConverter` to convert the data items into Chat messages and the other way around:
 
 <snippet id='chat-features-mvvm-converter'/>
 
-Add the RadChat control to your page with previously defined `ItemsSource` and `ItemConverter` properties:
+**4.** Add the `RadChat` control to your page with previously defined `ItemsSource` and `ItemConverter` properties:
 
 <snippet id='chat-features-mvvm-xaml' />
 	

--- a/controls/chat/overview.md
+++ b/controls/chat/overview.md
@@ -8,7 +8,7 @@ slug: chat-overview
 
 # .NET MAUI Conversational UI (Chat) Overview
 
-The Telerik UI for .NET MAUI Chat is a UI component that enables the implementation of conversational UI in .NET MAUI applications. It allows for the utilization of a chatbot framework, following a predefined logical tree, or integrating peer-to-peer chat capabilities.
+The Telerik UI for .NET MAUI Chat is a UI component that enables the implementation of conversational UI in .NET MAUI applications. It allows for use of a chatbot framework, following a predefined logical tree, or integrating peer-to-peer chat capabilities.
 
 ![Chat Overview](images/chat-overview.png)
 
@@ -16,7 +16,7 @@ The Telerik UI for .NET MAUI Chat is a UI component that enables the implementat
 
 * [A variety of chat items for great user experience]({%slug chat-items-overview %})&mdash;You can choose between simple text messages, various pickers, such as list view, calendar, date and time pickers, and cards.
 
-* [MVVM Support]({%slug chat-mvvm-support %})&mdash;With the `RadChat` control, you can easily utilize the Model-View-ViewModel pattern. You can achieve this by bounding the `ItemsSource` property to a collection of any data items that will be converted into chat items.
+* [MVVM Support]({%slug chat-mvvm-support %})&mdash;With the `RadChat` control, you can use the Model-View-ViewModel pattern. You can achieve this by bounding the `ItemsSource` property to a collection of any data items that will be converted into chat items.
 
 ## Next Steps
 

--- a/controls/chat/overview.md
+++ b/controls/chat/overview.md
@@ -8,15 +8,15 @@ slug: chat-overview
 
 # .NET MAUI Conversational UI (Chat) Overview
 
-**Telerik Chat for .NET MAUI** is a UI component that enables easy implementation of conversational UI in .NET MAUI applications, whether by utilizing certain chatbot framework, by following a predefined logical tree, or just for integrating peer-to-peer chat capabilities.
+The Telerik UI for .NET MAUI Chat is a UI component that enables the implementation of conversational UI in .NET MAUI applications. It allows for the utilization of a chatbot framework, following a predefined logical tree, or integrating peer-to-peer chat capabilities.
 
 ![Chat Overview](images/chat-overview.png)
 
 ## Key Features
 
-* [A variety of chat items for great user experience]({%slug chat-items-overview %})&mdash;You could choose between simple text messages, various pickers such as list view, calendar, date and time pickers, and cards.
+* [A variety of chat items for great user experience]({%slug chat-items-overview %})&mdash;You can choose between simple text messages, various pickers, such as list view, calendar, date and time pickers, and cards.
 
-* [MVVM Support]({%slug chat-mvvm-support %})&mdash;With RadChat control you could easily utilize the Model-View-ViewModel pattern. This could be achieved through the ItemsSource property that can be bound/set to a collection of any data items that should be then converted into chat items.
+* [MVVM Support]({%slug chat-mvvm-support %})&mdash;With the `RadChat` control, you can easily utilize the Model-View-ViewModel pattern. You can achieve this by bounding the `ItemsSource` property to a collection of any data items that will be converted into chat items.
 
 ## Next Steps
 
@@ -24,5 +24,7 @@ slug: chat-overview
 
 ## See Also
 
-- [Chat Items]({%slug chat-items-overview %})
-- [MVVM Support]({%slug chat-mvvm-support %})
+- [.NET MAUI Chat Product Page](https://www.telerik.com/maui-ui/chat-(conversational-ui))
+- [.NET MAUI Chat Forum Page](https://www.telerik.com/forums/maui?tagId=2061)
+- [Telerik .NET MAUI Blogs](https://www.telerik.com/blogs/mobile-net-maui)
+- [Telerik .NET MAUI Roadmap](https://www.telerik.com/support/whats-new/maui-ui/roadmap)

--- a/controls/chat/pickers/card-picker/imagecard.md
+++ b/controls/chat/pickers/card-picker/imagecard.md
@@ -6,7 +6,7 @@ position: 1
 slug: chat-imagecard
 ---
 
-# ImageCard 
+# `ImageCard` 
 
 `ImageCardContext` enhances the functionality of the `BasicCardContext` by providing an additional `Image` property, so you can add an image to the Card definition. 
 

--- a/controls/chat/pickers/card-picker/imagecard.md
+++ b/controls/chat/pickers/card-picker/imagecard.md
@@ -8,9 +8,9 @@ slug: chat-imagecard
 
 # ImageCard 
 
-`ImageCardContext` enhances the functionality of the `BasicCardContext` by providing an additional `Image` property, so you could add an image to the Card definition. 
+`ImageCardContext` enhances the functionality of the `BasicCardContext` by providing an additional `Image` property, so you can add an image to the Card definition. 
 
-Here is a quick example on how to create a sequence of ImageCards and show it through the RadChat Picker's control.
+Here is a quick example on how to create a sequence of Image Cards and show it through the `RadChatPicker` control.
 
 ```C#
 var cardsContext = new CardPickerContext {

--- a/controls/chat/pickers/card-picker/overview.md
+++ b/controls/chat/pickers/card-picker/overview.md
@@ -8,18 +8,18 @@ slug: chat-cardpicker
 
 # CardPicker Overview
 
-`RadChatPicker` control provides a `CardPickerContext` that can be used to display a list of cards. Each card presents more complex information in a user-friendly structured manner and allows the user to interact with it. 
+The `RadChatPicker` control provides a `CardPickerContext` that can be used to display a list of cards. Each card presents more complex information in a user-friendly structured manner and allows the user to interact with it. 
 
 `CardPickerContext` exposes the following property:
 
-* `Cards`&mdash;It is of type IEnumerable&lt;CardContext&gt; and contains the available Cards defined by the CardContext;
+* `Cards`&mdash;A property of type `IEnumerable<CardContext>` contains the available Cards defined by the `CardContext`;
 
 Depending on the information that is presented, the `CardContext` can be one of the following types:
 
-* `BasicCardContext`&mdash;For displaying a card with `Title`, `SubTitle` and `Description`;
-* `ImageCardContext`&mdash;Derives from BasicCardContext with an additional Image property;
+* `BasicCardContext`&mdash;For displaying a card with `Title`, `SubTitle`, and `Description`;
+* `ImageCardContext`&mdash;Derives from `BasicCardContext` with an additional `Image` property;
 
-Here is a quick example with BasicCardContext:
+Here is a quick example with `BasicCardContext`:
 
 <snippet id='chat-chatpicker-cardpicker-pickeritem' />
 
@@ -37,9 +37,9 @@ private IEnumerable<CardContext> GetCards(ChatItem chatItem)
 }
 ```
 	
-#### Card Actions
+## Card Actions
 
-Each card allows you to add a certain action that can be handled through a command. The `CardContext` exposes an `Actions` collection of type IEnumerable&lt;CardActionContext&gt; that supplies all the details needed for handling the action.
+Each card allows you to add a certain action that can be handled through a command. The `CardContext` exposes an `Actions` collection of type `IEnumerable<CardActionContext>` that supplies all the details needed for handling the action.
 
 `CardActionContext` provides the following properties:
 

--- a/controls/chat/pickers/card-picker/overview.md
+++ b/controls/chat/pickers/card-picker/overview.md
@@ -6,7 +6,7 @@ position: 0
 slug: chat-cardpicker
 ---
 
-# CardPicker Overview
+# `CardPicker` Overview
 
 The `RadChatPicker` control provides a `CardPickerContext` that can be used to display a list of cards. Each card presents more complex information in a user-friendly structured manner and allows the user to interact with it. 
 

--- a/controls/chat/pickers/datepicker.md
+++ b/controls/chat/pickers/datepicker.md
@@ -8,9 +8,9 @@ slug: chat-datepicker
 
 # .NET MAUI Chat DatePicker
 
-The `RadChatPicker` control provides a `DatePickerContext` that can be used to display a calendar to choose a date.
+The `RadChatPicker` control provides a `DatePickerContext` that you can use to display a calendar and allow the user to choose a date.
 
-`DatePickerContext` exposes the following properties you could use to provide a list of possible options to the user:
+`DatePickerContext` exposes the following properties that allow you to show a list of possible options to the user:
 
 * `SelectedDate`&mdash;Defines the currently selected date;
 * `MinDate`&mdash;Defines the min date that can be displayed and selected;
@@ -20,7 +20,7 @@ Here is a quick example on how to user DatePicker:
 
 <snippet id='chat-chatpicker-datepicker' />
 	
-#### Figure 1: Chat with DatePicker
+>caption Chat with DatePicker
 
 ![Chat Message](images/chat-date-picker.png)
 

--- a/controls/chat/pickers/itempicker.md
+++ b/controls/chat/pickers/itempicker.md
@@ -6,22 +6,22 @@ position: 3
 slug: chat-itempicker
 ---
 
-# .NET MAUI Chat ItemPicker 
+# .NET MAUI Chat `ItemPicker`
 
 The `RadChatPicker` control provides an `ItemPickerContext` that enables you to display a list of options the end user can choose from.
 
 `ItemPickerContext` exposes the following properties that allow you to show a list of possible options to the user:
 
-* `ItemsSource`&mdash;Defines the data source used to generate the content of the ItemPicker control;
-* `SelectionMode`&mdash;Defines whether users are allowed to select one or many items out of the provided ItemsSource;
+* `ItemsSource`&mdash;Defines the data source used to generate the content of the `ItemPicker` control;
+* `SelectionMode`&mdash;Defines whether users are allowed to select one or many items out of the provided `ItemsSource`;
 * `SelectedItems`&mdash;Defines the currently selected items;
 * `SelectedItem`&mdash;Defines the last selected item;
 
-The following example shows how to use the ItemPicker
+The following example shows how to use the `ItemPicker`
 
 <snippet id='chat-chatpicker-itempicker' />
 	
->caption Chat with ItemPicker
+>caption Chat with `ItemPicker`
 
 ![Chat Message](images/chat-item-picker.png)
 

--- a/controls/chat/pickers/itempicker.md
+++ b/controls/chat/pickers/itempicker.md
@@ -8,20 +8,20 @@ slug: chat-itempicker
 
 # .NET MAUI Chat ItemPicker 
 
-The `RadChatPicker` control provides an `ItemPickerContext` that can be used to display a list of options the end user could choose from.
+The `RadChatPicker` control provides an `ItemPickerContext` that enables you to display a list of options the end user can choose from.
 
-`ItemPickerContext` exposes the following properties you could use to provide a list of possible options to the user:
+`ItemPickerContext` exposes the following properties that allow you to show a list of possible options to the user:
 
 * `ItemsSource`&mdash;Defines the data source used to generate the content of the ItemPicker control;
 * `SelectionMode`&mdash;Defines whether users are allowed to select one or many items out of the provided ItemsSource;
 * `SelectedItems`&mdash;Defines the currently selected items;
 * `SelectedItem`&mdash;Defines the last selected item;
 
-Here is a quick example on how to user ItemPicker:
+The following example shows how to use the ItemPicker
 
 <snippet id='chat-chatpicker-itempicker' />
 	
-#### Figure 1: Chat with ItemPicker
+>caption Chat with ItemPicker
 
 ![Chat Message](images/chat-item-picker.png)
 

--- a/controls/chat/pickers/overview.md
+++ b/controls/chat/pickers/overview.md
@@ -8,46 +8,46 @@ slug: chat-picker-overview
 
 # ChatPicker Overview
 
-`RadChat` offers different pickers to present the user a selection of choices either as part of the conversation, or over the messages' view. 
+The `RadChat` component offers different pickers allowing you to present the user a selection of choices either as a part of the conversation, or over the messages' view. 
 
 Depending on the information that is presented and the choice that should be made, the pickers can be one of the types listed below. 
 
-* `DatePicker`&mdash;For displaying a calendar to choose a date
-* `TimePicker`&mdash;For displaying a clock view to choose a time
-* `ItemPicker`&mdash;For presenting a list of suggestions the end user could choose from
-* `CardPicker`&mdash;For presenting a list of cards with structured layout
+* `DatePicker`&mdash;Displays a Calendar to choose a date.
+* `TimePicker`&mdash;Displays a clock view to choose a time.
+* `ItemPicker`&mdash;Displays a list of suggestions the end user could choose from.
+* `CardPicker`&mdash;Displays a list of cards with structured layout.
 
-Each of these pickers is part of the `RadChatPicker` control and is defined through the corresponding `PickerContext` property, namely `DatePickerContext`, `TimePickerContext`, `ItemPickerContext`, etc.
+Each of these pickers is a part of the `RadChatPicker` control and is defined through the corresponding `PickerContext` property, namely `DatePickerContext`, `TimePickerContext`, `ItemPickerContext`, etc.
  
-`RadChatPicker` can be used in three different ways:
+You can use `RadChatPicker` in three different ways:
 
-* [Inline as part of the conversation](#inline-as-part-of-the-conversation) – through a PickerItem added to the Chat’s Items collection.
-* [Inside the Chat but not part of the conversation](#inside-the-chat-but-not-part-of-the-conversation) - the picker is placed between the entry and the conversation; implemented through the RadChat’s Picker property.
-* As a separate ChatPicker control - shown outside the RadChat control.
+* [Inline as a part of the conversation](#inline-as-part-of-the-conversation)–Through a `PickerItem` added to the Chat’s Items collection.
+* [Inside the Chat but not as a part of the conversation](#inside-the-chat---not-part-of-the-conversation)–The picker is placed between the entry and the conversation–implemented through the Chat’s Picker property.
+* As a separate Chat Picker control–Shown outside the `RadChat` control.
 
-### Inline as part of the conversation
+### Inline as Part of the Conversation
 
-In this case you would need to create an item of type `PickerItem` that actually derives from the `ChatItem`, set its `Context` and add it to the `Items` collection of the Chat. Here is a quick example:
+In this case, you need to create an item of type `PickerItem` that derives from the `ChatItem`. Set its `Context`, and add it to the `Items` collection of the Chat.
+
+The following example demonstrates how to use the `RadChatPicker` inline as a part of the conversation:
 
 <snippet id='chat-chatpicker-datepicker' />
 	
-When the user makes a selection, you can add a new TextMessage with the SelectedDate and remove the PickerItem from the conversation.
+When the user makes a selection, you can add a new `TextMessage` with the `SelectedDate` and remove the `PickerItem` from the conversation.
 
+### Inside the Chat - Not Part of the Conversation
 
-### Inside the Chat but not part of the conversation
-
-If you choose this approach you would need to create a `RadChatPicker` instance and set it to the `Picker` property of the Chat:
+If you choose this approach, you need to create a `RadChatPicker` instance and set it to the `Picker` property of the Chat:
 
 <snippet id='chat-pickeroverlay-xaml' />
 
-Then, when you need to display any of the available pickers, you will have to set the Context property of the ChatPicker. Check the example below with DatePickerContext:
+Then, when you need to display any of the available pickers, you set the `Context` property of the `ChatPicker`. The next example shows how to achieve this with `DatePickerContext`:
 
 <snippet id='chat-chatpicker-overlay-code' />
 			
-When the user chooses a date, the Context is reset to `null` and a new `TextMessage` with the `SelectedDate` can be added to the conversation. The `IsVisible` property of the picker can also be set to `false`.
+When the user selects a date, the `Context` is reset to `null` and a new `TextMessage` with the `SelectedDate` can be added to the conversation. The `IsVisible` property of the picker can also be set to `false`.
 
-
-In the example above, `RadChatPicker` is used for immediate selection by setting its `IsOkButtonVisible` and `IsCancelButtonVisible` to false. You could also show Ok and Cancel buttons and use the provided events/commands in order to handle the selection.
+In the example above, `RadChatPicker` is used for immediate selection by setting its `IsOkButtonVisible` and `IsCancelButtonVisible` to false. You can also show **OK** and **Cancel** buttons and use the provided events/commands to handle the selection.
 	
 ## See Also
 

--- a/controls/chat/pickers/overview.md
+++ b/controls/chat/pickers/overview.md
@@ -6,7 +6,7 @@ position: 0
 slug: chat-picker-overview
 ---
 
-# ChatPicker Overview
+# `ChatPicker` Overview
 
 The `RadChat` component offers different pickers allowing you to present the user a selection of choices either as a part of the conversation, or over the messages' view. 
 

--- a/controls/chat/pickers/timepicker.md
+++ b/controls/chat/pickers/timepicker.md
@@ -10,18 +10,18 @@ slug: chat-timepicker
 
 The `RadChatPicker` control provides a `TimePickerContext` that can be used to display a clock view to choose a time.
 
-`TimePickerContext` exposes the following properties you could use to adjust the clock items:
+`TimePickerContext` exposes the following properties that you can use to adjust the clock items:
 
-* `SelectedValue`&mdash;Defines the currently selected time
-* `StartTime`&mdash;It is of type TimeSpan and represents the starting time of the clock's items
-* `EndTime`&mdash;It is of type TimeSpan and corresponds to the time of the last clock item
-* `TimeInterval`&mdash;It is also of type TimeSpan and defines the step between the clock's items. Default value is 1 hour
+* `SelectedValue`&mdash;Defines the currently selected time.
+* `StartTime`&mdash;A property of type `TimeSpan` that represents the starting time of the clock's items.
+* `EndTime`&mdash;A property of type `TimeSpan` that corresponds to the time of the last clock item.
+* `TimeInterval`&mdash;A property of type `TimeSpan` that defines the step between the clock's items. Te default value is 1 hour.
 
-Here is a quick example on how to user TimePicker in RadChat:
+Here is a quick example on how to use the TimePicker in `RadChat`:
 
 <snippet id='chat-chatpicker-timepicker' />
 	
-#### Figure 1: Chat with TimePicker
+>caption Chat with TimePicker
 
 ![Chat Message](images/chat-time-picker.png)
 

--- a/controls/chat/suggested-actions.md
+++ b/controls/chat/suggested-actions.md
@@ -8,21 +8,21 @@ slug: chat-suggested-actions
 
 # .NET MAUI Chat Suggested Actions
 
-`RadChat` supports adding suggestions to the user. This can be done by adding `SuggestedActionsItem` instances to the `Items` collection of `RadChat`.
+The `RadChat` control enables you to add suggestions for the users. You can achieve this by adding `SuggestedActionsItem` instances to the `Items` collection of `RadChat`.
 
 ### Adding the Suggested Actions 
 
-The following example demonstrates how to create and setup a SuggestedActionsItem:
+The following example demonstrates how to create and set up a `SuggestedActionsItem`:
 
 <snippet id='chat-suggested-actions-code' />
 
-The `GetSuggestedActions` method then populates the `Actions` property with a collection of `SuggestedAction` items:
+Then, the `GetSuggestedActions` method populates the `Actions` property with a collection of `SuggestedAction` items:
 
 <snippet id='chat-suggested-actions-collection' />
 
-#### Figure 1: RadChat with suggested actions
+>caption `RadChat` with suggested actions
 
-![RadChat with suggested actions](images/chat-suggested-actions.png)
+![Chat with suggested actions](images/chat-suggested-actions.png)
 
 ## See Also
 

--- a/controls/chat/typing-indicator.md
+++ b/controls/chat/typing-indicator.md
@@ -8,41 +8,36 @@ slug: chat-typing-indicator
 
 # .NET MAUI Chat Typing Indicator
 
-The `TypingIndicator` functionality of RadChat can be used to indicate that a participant (or participants) is currently typing.
+The `TypingIndicator` functionality of the `RadChat` component allows you to indicate that other Chat participants are currently typing.
 
-By default, the `TypingIndicator` is not visible. As soon as its `Authors` (or ItemsSource) collection is updated, it is displayed with a text message indicating the authors' names. It can also be displayed explicitly by setting the `IsTyping` and/or `IsVisible` properties to `true`.
+By default, the `TypingIndicator` is not visible. As soon as its `Authors` (or `ItemsSource`) collection is updated, it is displayed with a text message indicating the authors' names. It can also be displayed explicitly by setting the `IsTyping` and/or `IsVisible` properties to `true`.
 
 The text message is built according to the count of authors like this:
 
-* If the collection of Authors contains 1 item: "[Author name] is typing";
-* If there are two authors: "[Author1 name] and [Author2 name] are typing";
-* In case of three authors: "[Author1 name], [Author2 name] and [Author3 name] are typing";
-* In case of more authors: "[Author1 name], [Author2 name] and 2 others are typing";
+* If the collection of `Authors` contains 1 item: "[Author name] is typing";
+* If the authors are two: "[Author 1 name] and [Author 2 name] are typing";
+* If the authors are three: "[Author 1 name], [Author 2 name] and [Author 3 name] are typing";
+* If the authors are four or more: "[Author 1 name], [Author 2 name] and 2 others are typing";
 
-When the Authors (or `ItemsSource`) collection is cleared, the `TypingIndicator` is hidden.
+When the `Authors` (or `ItemsSource`) collection is cleared, the `TypingIndicator` is hidden.
 
-In addition, by setting the `Text` property of the indicator, the text message could be replaced with any other of your choice.
+In addition, by setting the `Text` property of the indicator, the text message can be replaced with any other of your choice.
 
-#### Adding a TypingIndicator
+## Adding a Typing Indicator
 
-To add a typing indicator, just set the `TypingIndicator` property of the RadChat control:
+To add a typing indicator, set the `TypingIndicator` property of the `RadChat` control:
 
 <snippet id='chat-typingindicator-xaml' />
 	
-There are then two ways to display the typing indicator:
-
-#### Using the Authors collection:
-
-You can use directly `Authors` collection which is of type `ObservableCollection<Author>` to show the participants who are currently typing. Here is a quick example:
+To display the typing indicator, use the `Authors` collection. You can use the `Authors` collection, which is of type `ObservableCollection<Author>` to show the participants who are currently typing. Here is a quick example:
 
 <snippet id='chat-typingindicator-authors-code' />
 
-And the result is:
+The following images shows the results from the example above:
 
-#### Figure 1: RadChat with typing indicator
+>caption `RadChat` with a typing indicator
 
 ![RadChat with typing indicator](images/chat-typing-indicator.png)
-
 
 ## See Also
 

--- a/controls/chat/visual-structure.md
+++ b/controls/chat/visual-structure.md
@@ -8,18 +8,18 @@ slug: chat-visual-structure
 
 # .NET MAUI Chat Visual Structure
 
-RadChat exposes the following properties you could use to setup the component:
+The Telerik UI for .NET MAUI Chat exposes a set of properties that allow you to configure all elements in its visual structure.
 
 ![.NET MAUI Chat Visual Structure](images/chat-visualstructure.png)
 
 ## Legend
 
-- `Author`&mdash;Represents the current user who sends messages using the Chat UI. This instance determines the messages alignment – incoming messages are placed on the left, outgoing messages - on the right;
-- `Items`&mdash;Contains all the chat items included in the conversation such TextMessages, PickerItems, etc. For more details on the available chat items go to [Chat Items](slug %%) topic.
-- `Message`&mdash;Defines the current message typed into the input field
-- `Send Button`&mdash;Defines the button used to send messages
-- `Picker`&mdash;Defines the ChatPicker that is shown either as overlay over the messages’ view or inline as part of the conversation and could display different pickers in order to provide the end user with a selection of choices. Go to ChatPicker topic for more details on the matter.
-- `Typing Indicator`&mdash;Defines the indicator which is shown when one of the chat authors is typing
+- `Author`&mdash;Represents the current user who sends messages using the Chat UI. This instance determines the alignment of the messages—incoming messages are placed on the left, outgoing messages—on the right.
+- `Items`&mdash;Contains all the chat items included in the conversation, such text messages, picker items, and so on. For more details on the available Chat items, see the [Chat Items](slug %%) topic.
+- `Message`&mdash;Defines the current message typed into the input field.
+- `Send Button`&mdash;Defines the button used to send messages.
+- `Picker`&mdash;Defines the Chat Picker that is shown either as overlay over the messages’ view or inline as part of the conversation and could display different pickers in order to provide the end user with a selection of choices. See the [Chat Picker topic]({% slug chat-picker-overview %}) for more details.
+- `Typing Indicator`&mdash;Defines the indicator which is shown when one of the chat authors is typing.
 
 ## See Also
 

--- a/controls/chat/visual-structure.md
+++ b/controls/chat/visual-structure.md
@@ -18,7 +18,7 @@ The Telerik UI for .NET MAUI Chat exposes a set of properties that allow you to 
 - `Items`&mdash;Contains all the chat items included in the conversation, such text messages, picker items, and so on. For more details on the available Chat items, see the [Chat Items](slug %%) topic.
 - `Message`&mdash;Defines the current message typed into the input field.
 - `Send Button`&mdash;Defines the button used to send messages.
-- `Picker`&mdash;Defines the Chat Picker that is shown either as overlay over the messages’ view or inline as part of the conversation and could display different pickers in order to provide the end user with a selection of choices. See the [Chat Picker topic]({% slug chat-picker-overview %}) for more details.
+- `Picker`&mdash;Defines the Chat Picker that is shown either as overlay over the messages’ view or inline as part of the conversation and could display different pickers to provide the end user with a selection of choices. See the [Chat Picker topic]({% slug chat-picker-overview %}) for more details.
 - `Typing Indicator`&mdash;Defines the indicator which is shown when one of the chat authors is typing.
 
 ## See Also


### PR DESCRIPTION
### General recommendations, mostly fixed in this PR

|Where| What|
|-------|-------|
|controls\chat\overview.md|Don't use bold for component names|
|controls\chat\overview.md|Use names that are consistent with the marketing names of the components. Don't invent names like "Telerik Chat for .NET MAUI".|
|controls\chat\overview.md|Be consistent with the content of the See Also sections in the Overview articles between the various controls|
|controls\chat\getting-started.md|Be consistent with the content of the See Also sections in the GS articles between the various controls|
|controls\chat\pickers\card-picker\overview.md|Never skip heading levels. It is not allowed to go from ## to #### without using ### first.|
|all docs|When you refer to the component by using the class name, for example, `RadChat`, always render the class name in `monospace`.|

### Issues that this PR doesn't address and must be fixed additionally

|Where| What|
|-------|-------|
|controls\chat\getting-started.md|Extend the Additional Resources section|
|all chat docs|Use action verbs when creating anchor links for the See Also and the Related Articles sections|
|controls\chat\item-template-selector.md|Missing link in a reference to the MVVM topic. If the reason for missing links in such articles is that, at the time of writing, the referenced document didn't exist, you can avoid such issues by creating the `.md` files with the metadata in advance and leaving them blank. This will allow you to reference them and add the content later.|