### PR TITLE
Update Cursor Customization KBs

### DIFF
--- a/knowledge-base/autocomplete-cursor-customization.md
+++ b/knowledge-base/autocomplete-cursor-customization.md
@@ -29,7 +29,6 @@ res_type: kb
 
 This article shows you how to access the native element through the .NET MAUI handler for RadAutoComplete.
 
-
 ### Step 1.
 
 Subscribe to the HandlerChanged event of the RadAutoComplete you want to customize.
@@ -70,9 +69,6 @@ private void AutoComplete1_HandlerChanged(object sender, EventArgs e)
 }
 ```
 
->note It is not currently possible to change the Windows TextBox caret color in WinUI. This is a limitation in the WinAppSDK, not the Telerik control.
-
-
 ## Alternate Approach
 
 If you have many instances of the control on a single view, or throughout your app, you may want to consider creating your own custom class and subclassing the RadAutoComplete. In the custom control's class you can override the OnHandlerChanged instead of subscribing to an event handler.
@@ -111,6 +107,15 @@ public class MyCustomTelerikAutoComplete : Telerik.Maui.Controls.RadAutoComplete
     }
 }
 ```
+
+### Known Limitations
+
+It is not possible to apply caret customization on the following platforms:
+
+- Windows - WinUI3, and WinApp SDK, just does not have any access the caret of the native TextBox.
+- MacCatalyst - Due to a .NET MAUI issue, manually TextField.HintColor is not respected on MacCatalyst.
+
+If either of those situations change, then these limitations may be outdated and you can attempt the customization again.
 
 ## See Also
 

--- a/knowledge-base/entry-cursor-customization.md
+++ b/knowledge-base/entry-cursor-customization.md
@@ -29,7 +29,6 @@ res_type: kb
 
 This article shows you how to access the native element through the .NET MAUI handler for RadEntry via the RadMauiEntry object.
 
-
 ### Step 1.
 
 Subscribe to the HandlerChanged event of the RadEntry you want to customize.
@@ -58,9 +57,6 @@ private void Entry1_HandlerChanged(object sender, EventArgs e)
 }
 ```
 
->note It is not currently possible to change the Windows TextBox caret color in WinUI. This is a limitation in the WinAppSDK, not the Telerik control.
-
-
 ## Alternate Approach
 
 If you have many instances of the control on a single view, or throughout your app, you may want to consider creating your own custom class and subclassing the RadEntry. In the custom control's class you can override the OnHandlerChanged instead of subscribing to an event handler.
@@ -86,6 +82,15 @@ public class MyCustomTelerikEntry : Telerik.Maui.Controls.RadEntry
     }
 }
 ```
+
+### Known Limitations
+
+It is not possible to apply caret customization on the following platforms:
+
+- Windows - WinUI3, and WinApp SDK, just does not have any access the caret of the native TextBox.
+- MacCatalyst - Due to a .NET MAUI issue, manually TextField.HintColor is not respected on MacCatalyst.
+
+If either of those situations change, then these limitations may be outdated and you can attempt the customization again.
 
 ## See Also
 


### PR DESCRIPTION
Added information that TextField HintColor doesn't work on MacCatalyst, and moved both Windows and Mac limitations to its own section (instead of a note).