### PR TITLE
Update nuget-troubleshooting.md

### DIFF
--- a/installation/nuget/nuget-troubleshooting.md
+++ b/installation/nuget/nuget-troubleshooting.md
@@ -32,7 +32,7 @@ You can quickly test your credentials or a specific package search results, the 
     1. Enter [https://nuget.telerik.com/v3/index.json](https://nuget.telerik.com/v3/index.json) in the address bar and hit `Enter`.
     1. The web browser will prompt you to login, enter the credentials you want to test. You can test either:
         * Telerik Account credentials (email address and password)
-        1. Telerik NuGet Key (username "api-key", password is the full key value)
+        * Telerik NuGet Key (username "api-key", password is the full key value)
     1. You should now see a json result containing the general index listing. This confirms a successful login!
 1. Confirm Package Listing
     1. Enter [https://nuget.telerik.com/v3/search?q=telerik.ui.for.maui](https://nuget.telerik.com/v3/search?q=telerik.ui.for.maui) in the address bar and hit Enter.

--- a/installation/nuget/nuget-troubleshooting.md
+++ b/installation/nuget/nuget-troubleshooting.md
@@ -23,4 +23,20 @@ The issues listed below are common when upgrading to a new version of Telerik .N
 * Errors like `Unable to find package Telerik.UI.for.Maui with version` and `ProjectName depends on Telerik.UI.for.Maui (>= 7.1.0) but Telerik.UI.for.Maui 7.1.0 was not found` can be related to the subscription period&mdash;Review the [Package Version Not Found]({%slug package-version-not-found%}) article for more details on how to solve this behavior.
 * Error `Failed to retrieve information about ... from remote source` occurs when using the v2 server&mdash;The solution is to use the [v3 NuGet feed]({%slug failed-retrieve-info-remote-source%}).
 
+### Quick Access Test (Credentials or Network Access)
+
+You can quickly test your credentials or a specific package search results, the NuGet server is a REST service that can be accessed with a standard web browser. Try the following steps:
+
+1. Open a new **in-private/incognito** browser session/tab.
+1. Confirm Credentials
+    1. Enter [https://nuget.telerik.com/v3/index.json](https://nuget.telerik.com/v3/index.json) in the address bar and hit Enter.
+    1. The web browser will prompt you to login, enter the credentials you want to test. You can test either:
+        1. Telerik Account credentials (email address and password)
+        1. Telerik NuGet Key (username "api-key", password is the full key value)
+    1. You should now see a json result containing the general index listing. This confirms a successful login!
+1. Confirm Package Listing
+    1. Enter [https://nuget.telerik.com/v3/search?q=telerik.ui.for.maui](https://nuget.telerik.com/v3/search?q=telerik.ui.for.maui) in the address bar and hit Enter.
+    1. You should now see a json result containing a list of available packages that match the query.
+1. If you want to try again with different credentials (i.e. a different nuget key), close the incognito browser session and open a new one.
+
 @[template](/_contentTemplates/common/nuget.md#status-telerik-com)

--- a/installation/nuget/nuget-troubleshooting.md
+++ b/installation/nuget/nuget-troubleshooting.md
@@ -28,7 +28,7 @@ The issues listed below are common when upgrading to a new version of Telerik .N
 You can quickly test your credentials or a specific package search results, the NuGet server is a REST service that can be accessed with a standard web browser. Try the following steps:
 
 1. Open a new **in-private/incognito** browser session/tab.
-1. Confirm Credentials
+1. Confirm Credentials:
     1. Enter [https://nuget.telerik.com/v3/index.json](https://nuget.telerik.com/v3/index.json) in the address bar and hit Enter.
     1. The web browser will prompt you to login, enter the credentials you want to test. You can test either:
         1. Telerik Account credentials (email address and password)

--- a/installation/nuget/nuget-troubleshooting.md
+++ b/installation/nuget/nuget-troubleshooting.md
@@ -39,4 +39,6 @@ You can quickly test your credentials or a specific package search results, the 
     1. You should now see a json result containing a list of available packages that match the query.
 1. If you want to try again with different credentials (i.e. a different nuget key), close the incognito browser session and open a new one.
 
+>Tip If you get an error at any point in this process, review the list above for the specific error message and follow those dedicated instructions. For example, you may need to visit the [401 Unauthorized]({%slug error-unauthorized%}) or [401 Logon failed error]({%slug error-login-failed%}) articles. Alternatively, if you authenticate and get a json response, but the package version you're expecting isn't listed, the [Package Version Not Found]({%slug package-version-not-found%}) article is more relevant. 
+
 @[template](/_contentTemplates/common/nuget.md#status-telerik-com)

--- a/installation/nuget/nuget-troubleshooting.md
+++ b/installation/nuget/nuget-troubleshooting.md
@@ -31,7 +31,7 @@ You can quickly test your credentials or a specific package search results, the 
 1. Confirm Credentials:
     1. Enter [https://nuget.telerik.com/v3/index.json](https://nuget.telerik.com/v3/index.json) in the address bar and hit `Enter`.
     1. The web browser will prompt you to login, enter the credentials you want to test. You can test either:
-        1. Telerik Account credentials (email address and password)
+        * Telerik Account credentials (email address and password)
         1. Telerik NuGet Key (username "api-key", password is the full key value)
     1. You should now see a json result containing the general index listing. This confirms a successful login!
 1. Confirm Package Listing

--- a/installation/nuget/nuget-troubleshooting.md
+++ b/installation/nuget/nuget-troubleshooting.md
@@ -29,7 +29,7 @@ You can quickly test your credentials or a specific package search results, the 
 
 1. Open a new **in-private/incognito** browser session/tab.
 1. Confirm Credentials:
-    1. Enter [https://nuget.telerik.com/v3/index.json](https://nuget.telerik.com/v3/index.json) in the address bar and hit Enter.
+    1. Enter [https://nuget.telerik.com/v3/index.json](https://nuget.telerik.com/v3/index.json) in the address bar and hit `Enter`.
     1. The web browser will prompt you to login, enter the credentials you want to test. You can test either:
         1. Telerik Account credentials (email address and password)
         1. Telerik NuGet Key (username "api-key", password is the full key value)


### PR DESCRIPTION
Added a section that used to be in the Xamarin docs, but was never added to the Maui docs. This is a very fast and helpful way to check your credentials/access to the NuGet service.