### PR TITLE
Update set-up-your-license.md

### DIFF
--- a/installation/licensing/set-up-your-license.md
+++ b/installation/licensing/set-up-your-license.md
@@ -31,7 +31,8 @@ To activate the Telerik UI for .NET MAUI controls:
 
 * Copy the [downloaded](#downloading-the-license-key) `telerik-license.txt` license key file to your home directory. This makes the license key available to all projects that you develop on your computer:
 
-    * For Windows: `%AppData%\Roaming\Telerik\telerik-license.txt`. An example of a full path to the `telerik-license.txt` file location: `C:\Users\your-username\AppData\Roaming\Telerik\telerik-license.txt`
+    * For Windows: `%AppData%\Telerik\telerik-license.txt`.
+        * For the standard Windows user, that path resolves to `C:\Users\[windows_username]\AppData\Roaming\Telerik\telerik-license.txt`, it can resolve differently for service accounts.
     * For Mac/Linux: `~/.telerik/telerik-license.txt`. If `.telerik` folder does not exist, create such, and paste the `telerik-license.txt` file in it.
     
 * Alternatively, copy the `telerik-license.txt` license key file to the root folder of your project. This makes the license key available only to this project. Do not commit the file to source control as this is your personal license key.


### PR DESCRIPTION
There was an error in the env variable path for %appdata% where it would have resolved to /AppData/Roaming/Roaming/Telerik.

I fixed that, and also improved the explanation of the path resolution.