### PR TITLE
Fix CollectionView documentation errors

### DIFF
--- a/controls/collectionview/events.md
+++ b/controls/collectionview/events.md
@@ -93,7 +93,9 @@ The CollectionView provides the `Scrolled` event, which is raised when scrolling
 
 * `SelectionChanged`&mdash;Raised when the current selection changes. The `SelectionChanged` event handler receives two parameters:
 	* The sender argument, which is of type `object`, but can be cast to the `RadCollectionView` type.
-	* A `EventArgs` object, which provides information on the `SelectionChanged` event.
+	* A `RadSelectionChangedEventArgs` object, which provides the following properties:
+		* `AddedItems` (`IEnumerable<object>`)&mdash;The selected items.
+		* `RemovedItems` (`IEnumerable<object>`)&mdash;The deselected items.
 
 ## See Also
 

--- a/controls/collectionview/filtering.md
+++ b/controls/collectionview/filtering.md
@@ -111,7 +111,7 @@ The descriptor exposes the following properties:
 
 ## Nested Property Text Filter Descriptor
 
-The `NestedProprtyTextFilterDescriptor` is a descriptor which filters the nested properties.
+The `NestedPropertyTextFilterDescriptor` is a descriptor which filters the nested properties.
 
 The descriptor exposes the following properties:
 

--- a/controls/collectionview/grouping/overview.md
+++ b/controls/collectionview/grouping/overview.md
@@ -39,7 +39,7 @@ In a multi-level grouping scenario, the last inner group from the parent group w
 
 Style the group header by setting the following properties:
 
-* `GroupContainerStyle` (`Style` with target type `RadCollectionViewGroupView`)&mdash;Specifies the style applied to the group header when grouping is applied.
+* `GroupViewStyle` (`Style` with target type `RadCollectionViewGroupView`)&mdash;Specifies the style applied to the group header when grouping is applied.
 
 ## See Also
 

--- a/controls/collectionview/item-swipe/item-swipe-commands.md
+++ b/controls/collectionview/item-swipe/item-swipe-commands.md
@@ -14,10 +14,10 @@ The .NET MAUI CollectionView provides the following commands related to swipe ac
 - `SwipeStartingCommand`(`ICommand`)&mdash;Occurs when an item is about to be swiped. The command parameter is of the `CollectionViewSwipeStartingCommandContext` type that provides the following properties:
   - `Item`(`object`)&mdash;The item that will be swiped.
   - `Cancel`(`bool`)&mdash;If you set this value to `false`, the swiping will be canceled.
-- `Swiping`(`ICommand`)&mdash;Occurs while the user is swiping the item. The command parameter is of the `CollectionViewSwipingCommandContext` type that provides the following properties:
+- `SwipingCommand`(`ICommand`)&mdash;Occurs while the user is swiping the item. The command parameter is of the `CollectionViewSwipingCommandContext` type that provides the following properties:
   - `Item`(`object`)&mdash;The item that is being swiped.
   - `Offset`(`double`)&mdash;The offset of the swiped item from its initial position.
-- `ItemSwipeCompleted`(`ICommand`)&mdash;Occurs when the swiping of an item is completed. The command parameter is of the `CollectionViewSwipeCompletedCommandContext` type that provides the following properties:
+- `SwipeCompletedCommand`(`ICommand`)&mdash;Occurs when the swiping of an item is completed. The command parameter is of the `CollectionViewSwipeCompletedCommandContext` type that provides the following properties:
   - `Item`(`object`)&mdash;The item that was swiped.
   - `Offset`(`double`)&mdash;The final offset of the swiped item.
 

--- a/controls/collectionview/listview-migration.md
+++ b/controls/collectionview/listview-migration.md
@@ -17,8 +17,8 @@ When migrating the Telerik .NET MAUI ListView, consider the following difference
 | Telerik .NET MAUI ListView | Telerik .NET MAUI CollectionView |
 | ------------- | ------------- |
 | Presenting the data through cells&mdash;`ListViewTextCell`, `ListViewTemplateCell` | [Presenting the data]({%slug collectionview-data-binding%}) through a `DisplayMemberPath` property or by defining an `ItemTemplate` |
- Selection&mdash;`None`, `Single` or `Multiple`, provide an option to set selection gesture - `Tap`, `Hold` | [Selection]({%slug collectionview-selection%})&mdash;`None`, `Single` or `Multiple`, no selection gesture |
-| Grouping through `PropertyGroupDescriptor` or `DelegateGroupDescriptor`, methods for expanding/collapsing groups, multi-level grouping, sticky group headers | [Grouping]({%slug collectionview-grouping%}) through `PropertyGroupDescriptor` or `DelegateGroupDescriptor`, methods for expanding/collapsing groups, multi-level grouping, no sticky group headers |
+ Selection&mdash;`None`, `Single` or `Multiple`, provide an option to set selection gesture - `Tap`, `Hold` | [Selection]({%slug collectionview-selection%})&mdash;`None`, `Single` or `Multiple`, supports selection gesture - `Tap` (default), `Hold` |
+| Grouping through `PropertyGroupDescriptor` or `DelegateGroupDescriptor`, methods for expanding/collapsing groups, multi-level grouping, sticky group headers | [Grouping]({%slug collectionview-grouping%}) through `PropertyGroupDescriptor` or `DelegateGroupDescriptor`, methods for expanding/collapsing groups, multi-level grouping, sticky group headers via `EnableStickyGroupHeaders` |
 | Sorting through `PropertySortDescriptor` or `DelegateSortDescriptor` | [Sorting]({%slug collectionview-sorting%}) through `PropertySortDescriptor` or `DelegateSortDescriptor` |
 | Filtering through `DelegateFilterDescriptor` | [Filtering]({%slug collectionview-filtering%}) through various filter descriptors, such as `TextFilterDescriptor`, `NumericalFilterDescriptor`, etc |
 | Header and Footer templates | [Header and Footer templates]({%slug collectionview-header-footer%}) |

--- a/controls/collectionview/scrolling.md
+++ b/controls/collectionview/scrolling.md
@@ -79,5 +79,4 @@ The CollectionView provides the `Scrolled` event, which is raised when scrolling
 - [Sorting]({%slug collectionview-sorting%})
 - [Selection]({%slug collectionview-selection%})
 - [Commands]({%slug collectionview-commands%})
-- [Events]({%slug collectionview-commands%})
-
+- [Events]({%slug collectionview-events%})

--- a/controls/collectionview/styling/group-style-selector.md
+++ b/controls/collectionview/styling/group-style-selector.md
@@ -55,4 +55,4 @@ This is the result on WinUI:
 - [Sorting]({%slug collectionview-sorting%})
 - [Selection]({%slug collectionview-selection%})
 - [Commands]({%slug collectionview-commands%})
-- [Events]({%slug collectionview-commands%})
+- [Events]({%slug collectionview-events%})

--- a/controls/collectionview/styling/group-style.md
+++ b/controls/collectionview/styling/group-style.md
@@ -56,4 +56,4 @@ This is the result on WinUI:
 - [Sorting]({%slug collectionview-sorting%})
 - [Selection]({%slug collectionview-selection%})
 - [Commands]({%slug collectionview-commands%})
-- [Events]({%slug collectionview-commands%})
+- [Events]({%slug collectionview-events%})

--- a/controls/collectionview/styling/item-style-selector.md
+++ b/controls/collectionview/styling/item-style-selector.md
@@ -51,4 +51,4 @@ This is the result on WinUI:
 - [Sorting]({%slug collectionview-sorting%})
 - [Selection]({%slug collectionview-selection%})
 - [Commands]({%slug collectionview-commands%})
-- [Events]({%slug collectionview-commands%})
+- [Events]({%slug collectionview-events%})

--- a/controls/collectionview/styling/item-style.md
+++ b/controls/collectionview/styling/item-style.md
@@ -67,5 +67,5 @@ This is the result on WinUI:
 - [Sorting]({%slug collectionview-sorting%})
 - [Selection]({%slug collectionview-selection%})
 - [Commands]({%slug collectionview-commands%})
-- [Events]({%slug collectionview-commands%})
+- [Events]({%slug collectionview-events%})
 


### PR DESCRIPTION
Fixes several errors found during source-verified review of the CollectionView docs.

**Bugs fixed:**
- events.md: SelectionChanged args listed as plain EventArgs; fixed to RadSelectionChangedEventArgs with AddedItems/RemovedItems
- item-swipe-commands.md: Swiping command property name -> SwipingCommand; ItemSwipeCompleted -> SwipeCompletedCommand (source verified)
- filtering.md: NestedProprtyTextFilterDescriptor typo -> NestedPropertyTextFilterDescriptor
- listview-migration.md: CollectionView does support SelectionGesture (Tap/Hold) and sticky group headers (EnableStickyGroupHeaders)
- grouping/overview.md: GroupContainerStyle -> GroupViewStyle (matches source and all other articles)

**Broken links fixed:**
- scrolling.md, styling/item-style.md, styling/item-style-selector.md, styling/group-style.md, styling/group-style-selector.md all had the Events See Also link pointing to the commands slug instead of the events slug.