### PR TITLE
ComboBox: Correct source-backed API names in docs

### DIFF
--- a/controls/combobox/configuration.md
+++ b/controls/combobox/configuration.md
@@ -68,7 +68,7 @@ To manage the drop-down of the ComboBox, use the following properties:
 * `DropDownMaxHeight` (`double`)&mdash;Defines the max height of the drop-down. Always set the `DropDownMaxHeight`, so that you can have a predefined height for the drop-down. If using both the `DropDownMaxHeight` and `DropDownHeight` properties, the max height value must be higher.
 * `DropDownVerticalOffset` (`double`)&mdash;Defines the vertical offset of the drop-down part of the control. This property allows an option to modify the control with no space between the ComboBox and the drop-down.
 * `IsDropDownOpen` (`bool`)&mdash;Defines whether the drop-down part of the control is opened. The default value is `true`. 
-* `IsDropdownClosedOnSelection` (`bool`)&mdash;Defines whether the drop-down will be closed when the item is selected or deselected. The default value is `true`.
+* `IsDropDownClosedOnSelection` (`bool`)&mdash;Defines whether the drop-down will be closed when the item is selected or deselected. The default value is `true`.
 
 Here is an example that uses the `DropDownWidth` property:
 
@@ -86,7 +86,7 @@ Here is an example that uses the `DropDownVerticalOffset` property:
 
 <snippet id='combobox-configuration-dropdownverticaloffset'/>
 
-Here is an example with `IsDropdownClosedOnSelection` property set:
+Here is an example with `IsDropDownClosedOnSelection` property set:
 
 <snippet id='combobox-configuration-dropdownvisibility-isdropdownclosed'/>
 

--- a/controls/combobox/styling.md
+++ b/controls/combobox/styling.md
@@ -55,7 +55,7 @@ The following properties style the ComboBox DropDown:
 
 * `DropDownBorderColor`(`Color`)&mdash;Defines the color of the border that surrounds the DropDown part of the control.
 * `DropDownBorderThickness`(`Thickness`)&mdash;Defines the thickness of the border that surrounds the DropDown part of the control.
-* `DropDownBorderCornerRadius`(`Thickness`)&mdash;Defines the corner radius of the border that surrounds the DropDownn part of the control.
+* `DropDownCornerRadius`(`Thickness`)&mdash;Defines the corner radius of the border that surrounds the DropDown part of the control.
 * `DropDownBackgroundColor`(`Color`)&mdash;Defines the background color of the DropDown part of the control.
 * `DropDownButtonStyle`(of type `Style` with target type `Telerik.Maui.Controls.RadTemplatedButton`)&mdash;Defines the style for the DropDown button.
 


### PR DESCRIPTION
## Change Summary

- Corrected ComboBox documentation wording so the property names match the source-backed Telerik API.
- Updated the configuration and styling articles to use `IsDropDownClosedOnSelection` and `DropDownCornerRadius`.

## Affected Controls

- None

## Testing Notes

- No automated tests were added; this is a documentation-only fix.
- Review the updated ComboBox configuration and styling topics for the corrected property names.

## Breaking Change

- Breaking change: No

## Release Notes Text

- Not available (no linked work item context).
