### PR TITLE
Border: Fix copy-paste Barcode references in Border docs

### DIFF
--- a/controls/border/styling.md
+++ b/controls/border/styling.md
@@ -1,7 +1,7 @@
 ---
 title: Styling
 page_title: .NET MAUI Border Documentation | Styling
-description: Learn more about how to set the color and thickness of the Telerik UI for .NET MAUI Barcode.
+description: Learn more about how to set the color and thickness of the Telerik UI for .NET MAUI Border.
 tags: .net maui, telerik .net maui, ui for .net maui, border, microsoft .net maui
 position: 40
 previous_url: /controls/border/border-styling

--- a/controls/border/xamarin-migration.md
+++ b/controls/border/xamarin-migration.md
@@ -26,5 +26,5 @@ When migrating the Border from Xamarin to .NET MAUI, consider the following diff
 
 * [Migrating from Xamarin.Forms to .NET MAUI]({% slug migrate-to-net-maui %})
 * [.NET MAUI Sample Applications]({% slug sampleapps-overview %})
-* [.NET MAUI Barcode Product Page](https://www.telerik.com/maui-ui/barcode)
-* [.NET MAUI Barcode Forum Page](https://www.telerik.com/forums/maui?tagId=1780)
+* [.NET MAUI Border Product Page](https://www.telerik.com/maui-ui/border)
+* [.NET MAUI Border Forum Page](https://www.telerik.com/forums/maui?tagId=1763)


### PR DESCRIPTION

Ready For Test: N/A

## Change Summary

- Fixed two copy-paste errors in the `controls/border/` docs where "Barcode" was left in place of "Border":
  - `styling.md`: `description` frontmatter field said "Telerik UI for .NET MAUI **Barcode**"
  - `xamarin-migration.md`: "See Also" links pointed to the Barcode product page and Barcode forum page instead of Border

## Affected Controls

- None (docs-only fix)

## Testing Notes

- No automated tests needed for docs metadata fixes.
- Verify the corrected links resolve: [Border Product Page](https://www.telerik.com/maui-ui/border) and [Border Forum](https://www.telerik.com/forums/maui?tagId=1763).

## Breaking Change

- Breaking change: No

## Release Notes Text

- Not available (no linked work item context).
