### PR TITLE
Scheduler: Fix MaxOccurrences typo and SpecialSlotStyleSelector scope in docs

### DIFF
--- a/controls/scheduler/recurrence/recurrence-pattern.md
+++ b/controls/scheduler/recurrence/recurrence-pattern.md
@@ -22,7 +22,7 @@ Check below a list of the properties exposed by the `RecurrencePattern` class:
 *  `MinutesOfHour`&mdash;Defines the minutes of an hour. 
 * `FirstDayOfWeek` &mdash; Defines the day on which the week starts.
 * `Interval` &mdash;Defines the interval.
-* `MaxOccurences`&mdash;Defines the limit for the number of occurrences.
+* `MaxOccurrences`&mdash;Defines the limit for the number of occurrences.
 * `MonthOfYear` &mdash;Defines the month in the year.
 * `RecursUntil`&mdash; Defines the end date of the appointment occurrences.
 

--- a/controls/scheduler/styling/special-slots-styling.md
+++ b/controls/scheduler/styling/special-slots-styling.md
@@ -10,7 +10,7 @@ slug: scheduler-special-slots-styling
 
 The Scheduler for .NET MAUI control makes it easy to customize the look & feel of the special slots.
 
-The Scheduler's ViewDefinitions (Day, Week, MultiDay and Month) provide a `SpecialSlotStyleSelector` (`Telerik.Maui.Controls.IStyleSelector`) property which conditionally applies different styles to special slots depending on some logic.
+The Scheduler's ViewDefinitions (Day, Week and MultiDay) provide a `SpecialSlotStyleSelector` (`Telerik.Maui.Controls.IStyleSelector`) property which conditionally applies different styles to special slots depending on some logic.
 
 In the example special slots are used to distinguish the non-working hours. In addition, the custom `SpecialSlotStyleSelector` applies separate style non-working hours during the week day and the weekend.
 


### PR DESCRIPTION


## Change Summary

Two inaccuracies in the Scheduler docs, both discovered by cross-checking docs against `telerik/maui` source during component skill authoring:

1. **`recurrence/recurrence-pattern.md`** — `MaxOccurences` (one 'r') corrected to `MaxOccurrences` (two 'r's) to match the source property name in `RecurrencePattern.cs`.

2. **`styling/special-slots-styling.md`** — "Day, Week, MultiDay **and Month**" corrected to "Day, Week and MultiDay". `SpecialSlotStyleSelector` is defined on `MultidayViewDefinitionBase`; `MonthViewDefinition` inherits directly from `ViewDefinitionBase` and does not have this property.

## Affected Controls

- None (docs-only fixes)

## Testing Notes

- No automated tests needed.
- Verify `RecurrencePattern.MaxOccurrences` compiles correctly with the documented spelling.
- Verify that `MonthViewDefinition` does not expose `SpecialSlotStyleSelector` (setting it on a `MonthViewDefinition` in XAML should produce a compile error or unknown property warning).

## Breaking Change

- Breaking change: No

## Release Notes Text

- Not available (no linked work item context).
