### PR TITLE
DataGrid: Fix 13 docs inaccuracies found during source verification

### DIFF
--- a/controls/datagrid/cells/current-cell.md
+++ b/controls/datagrid/cells/current-cell.md
@@ -15,7 +15,7 @@ slug: datagrid-current-cell
 
 The DataGrid allows you to use the `CurrentCell` property of type `DataGridCellInfo` to programmatically modify the current cell during keyboard navigation, when using the mouse, and so on.
 
-The DataGrid also supports the `CurrentCellChanged` event which is invoked when the current cell changes as a result of user interaction with the keyboard.
+The DataGrid also supports the `CurrentCellChanged` event, which is invoked whenever the `CurrentCell` changes (for example, through keyboard navigation, mouse/touch interaction, or programmatic updates).
 
 The `CurrentCellChanged` event handler receives the following parameters:
 

--- a/controls/datagrid/columns/column-types/time-column.md
+++ b/controls/datagrid/columns/column-types/time-column.md
@@ -1,7 +1,7 @@
 ---
 title: Time Column
 page_title: .NET MAUI DataGrid Documentation - Time Column
-description: Learn how to use the Time column in the Telerik UI for .NET MAUI DataGrid to display and edit the time portion of DateTime data.
+description: Learn how to use the Time column in the Telerik UI for .NET MAUI DataGrid to display and edit TimeSpan data.
 position: 4
 slug: datagrid-columns-time-column
 ---

--- a/controls/datagrid/columns/overview.md
+++ b/controls/datagrid/columns/overview.md
@@ -44,7 +44,7 @@ Using the built-in auto generation of columns does not fit all scenarios. In suc
 * [Numerical Column]({%slug datagrid-columns-numerical-column%})&mdash;Represents an extended `DataGridTextColumn` that presents numerical data (`int` and `double` types).
 * [Boolean Column]({%slug datagrid-columns-boolean-column%})&mdash;An extended `DataGridTextColumn` implementation that presents Boolean data.
 * [Date Column]({%slug datagrid-columns-date-column%})&mdash;An extended `DataGridTextColumn` that presents data of type `DateTime`.
-* [Time Column]({%slug datagrid-columns-time-column%})&mdash;Represents an extended `DataGridTextColumn` that presents the `TimeOfDay` of a `DateTime` type.
+* [Time Column]({%slug datagrid-columns-time-column%})&mdash;Represents an extended `DataGridTextColumn` that presents data of type `TimeSpan`.
 * [ComboBox Column]({%slug datagrid-columns-combobox-column%})&mdash;Represents an extended `DataGridTextColumn`  which cell value editor is a Telerik.Maui.Controls.RadComboBox control.
 * [Template Column]({%slug datagrid-columns-template-column%})&mdash;Represents a column that uses a `DataTemplate` to describe the content of each associated grid cell.
 * [ToggleRowDetails Column]({%slug datagrid-columns-toggle-column%})&mdash;Represents a column that allows the user to show and hide the row details for an item.

--- a/controls/datagrid/columns/resizing.md
+++ b/controls/datagrid/columns/resizing.md
@@ -10,7 +10,7 @@ slug: datagrid-column-resizing
 
 Columns inside the [Telerik UI for .NET MAUI DataGrid]({%slug datagrid-overview%}) are resizable by default. The feature is available only on Desktop - `WinUI` and `MacCatalyst`.
 
-On `WinUI` and `MacOS`, you can change the column width by positioning the mouse over the column's vertical grid line (in the column header) and dragging it until the desired size is achieved.
+On `WinUI` and `MacCatalyst`, you can change the column width by positioning the mouse over the column's vertical grid line (in the column header) and dragging it until the desired size is achieved.
 
 ![DataGrid Column Resizing](../images/column-resizing.png)
 

--- a/controls/datagrid/commands/overview.md
+++ b/controls/datagrid/commands/overview.md
@@ -32,7 +32,7 @@ The table below shows all commands in the DataGrid control and for each of the a
 | Commands | Object type |
 | -------- | ---------- |
 | Unknown | `DataGridColumn` |
-| `ColumnHeaderTap`  | `DataGridTextColumn` |
+| `ColumnHeaderTap`  | `DataGridColumn` |
 | `GroupHeaderTap`      | `GroupHeaderContext` |
 | `GroupHeaderButtonTap`      | `GroupHeaderContext` |
 | `CellTap` | `DataGridCellInfo` |
@@ -48,8 +48,13 @@ The table below shows all commands in the DataGrid control and for each of the a
 | `ApplyFilter` | `FilterTapContext` |
 | `CloseFilter` | `FilterTapContext` |
 | `ResetFilter` | `FilterTapContext` |
+| `ApplyGrouping` | `DataGridColumn` or `GroupDescriptorBase` |
+| `MoreTap` | `FilterTapContext` |
 | `KeyDown` | `KeyboardInfo` |
 | `ToggleRowDetailsButtonTap` | the `type` is the data model |
+| `AIFloatingActionButtonTap` | `null` |
+| `PromptRequest` | `DataGridPromptRequestCommandContext` |
+| `CancelPromptRequest` | `null` |
 
 >tip For an outline of all DataGrid features review the [.NET MAUI DataGrid Overview]({%slug datagrid-overview%}) article.
 

--- a/controls/datagrid/editing.md
+++ b/controls/datagrid/editing.md
@@ -30,12 +30,12 @@ The following table lists the integrated .NET MAUI control for editing the value
 
 | Column Type 		| Editor 			|
 |-------------------|-------------------|
-| `TextColumn`		| Entry				|
+| `TextColumn`		| RadEntry			|
 | `NumericalColumn`	| RadNumericInput	|
 | `BooleanColumn`	| CheckBox		    |
 | `DateColumn`		| RadDatePicker		|
 | `TimeColumn`		| RadTimePicker		|
-| `PickerColumn`	| RadComboBox	    |
+| `DataGridComboBoxColumn`	| RadComboBox	    |
 | `TemplateColumn`	| A custom editor by defining `CellEditTemplate`. |
 
 ## Custom Editors
@@ -72,4 +72,3 @@ The following snippet shows a `CellEditorStyle` applied to the `DataGridTextColu
 - [Editing Commands in the Telerik UI for .NET MAUI DataGrid]({%slug datagrid-commands-editing%})
 - [Column Cell Templates in the .NET MAUI DataGrid]({%slug datagrid-cell-templates%})
 - [Styling the Columns of the .NET MAUI DataGrid]({%slug datagrid-columns-styling%})
-

--- a/controls/datagrid/filtering/overview.md
+++ b/controls/datagrid/filtering/overview.md
@@ -31,7 +31,7 @@ The Telerik DataGrid allows you to apply custom filter control to the DataGrid c
 
 ## Programmatic Filtering
 
-Programmatic filtering is achieved by adding different filter descriptors in the `FilterDescriptor` collection of the control.
+Programmatic filtering is achieved by adding different filter descriptors in the `FilterDescriptors` collection of the control.
 
 >tip Go to the [Programmatic Filtering]({%slug datagrid-programmatic-filtering%}) topic for detailed information about the provided filter descriptors.
 

--- a/controls/datagrid/filtering/programmatic-filtering.md
+++ b/controls/datagrid/filtering/programmatic-filtering.md
@@ -9,7 +9,7 @@ slug: datagrid-programmatic-filtering
 # Programmatic Filtering
 
 Programmatic Filtering can be used for external filtering. For example, disable the built-in filtering UI and to filter the data in the grid programmatically. 
-Programmatic Filtering is achieved by adding different filter descriptors in the `FilterDescriptor` collection of the [.NET MAUI DataGrid]({%slug datagrid-overview%}) control. 
+Programmatic Filtering is achieved by adding different filter descriptors in the `FilterDescriptors` collection of the [.NET MAUI DataGrid]({%slug datagrid-overview%}) control. 
 
 The following descriptor types are supported:
 
@@ -100,7 +100,7 @@ It exposes the following properties:
 ```XAML
 <telerik:TimeSpanFilterDescriptor PropertyName="Time"
                                   Operator="IsLessThan"
-                                  Value="22/11/21"/>
+                                  Value="22:11:21"/>
 ```
 
 ### Boolean Filter Descriptor
@@ -149,10 +149,16 @@ The `DistinctValuesFilterDescriptor` is a descriptor which filters by distinct v
 It exposes the following properties:
 
 * `PropertyName`&mdash;Gets or sets the name of the property that is used to retrieve the filter value.
-* `Value`&mdash;Gets or sets the value used in the comparisons. This is the right operand of the comparison.
+* `Value`&mdash;Gets or sets the collection of values used in the comparisons (for example, `HashSet<object>`).
 
-```XAML
-<telerik:DistinctValuesFilterDescriptor PropertyName="Country" Value="Austria" />
+```C#
+var distinctValuesFilterDescriptor = new DistinctValuesFilterDescriptor
+{
+    PropertyName = "Country",
+    Value = new HashSet<object> { "Austria", "Spain" }
+};
+
+this.dataGrid.FilterDescriptors.Add(distinctValuesFilterDescriptor);
 ```
 
 ### Composite Filter Descriptor

--- a/controls/datagrid/overview.md
+++ b/controls/datagrid/overview.md
@@ -90,7 +90,9 @@ The Telerik UI for .NET MAUI DataGrid allows you to display additional informati
 
 ## Empty Template
 
-When the .NET MAUI DataGrid does not have any data (`ItemsSource` is null or the collection is empty), an [empty template]({%slug datagrid-empty-template%}) is displayed in the DataGrid.
+When the .NET MAUI DataGrid does not have any data, you can display an [empty template]({%slug datagrid-empty-template%}) in the DataGrid.
+
+By default, `EmptyContentDisplayMode` is `ItemsSourceNull`, which means the empty template is shown only when `ItemsSource` is `null` (not when it is an empty collection). To also show it for empty collections, set `EmptyContentDisplayMode` to `ItemsSourceNullOrEmpty`.
 
 ## Commands
 

--- a/controls/datagrid/search-as-you-type.md
+++ b/controls/datagrid/search-as-you-type.md
@@ -103,7 +103,7 @@ Here is an example of how you can utilize `SearchStarting` to modify the way the
 
 **2.** Add a sample `SearchStarting` event handler:
 
-<snippet id='scheduler-search-searchstarting-event' />
+<snippet id='datagrid-search-searchstarting-event' />
 
 ![Telerik .NET MAUI DataGrid Search by Two Terms](images/datagrid-search-searchstarting.png)
 

--- a/controls/datagrid/selection.md
+++ b/controls/datagrid/selection.md
@@ -65,8 +65,8 @@ Once you make a selection, you can get or modify the collection with the selecte
 
 The `SelectedItem` property gets or sets the value of the selected item in the `DataGrid`. The type of the `SelectedItem` depends on the value of the `SelectionUnit`.
 
-* `Row`&mdash;`SelectedItem` is of type `DataGridCellInfo`.
-* `Cell`&mdash;`SelectedItem` is the same type as the business object.
+* `Row`&mdash;`SelectedItem` is the same type as the business object.
+* `Cell`&mdash;`SelectedItem` is of type `DataGridCellInfo`.
 
 ## Events
 

--- a/controls/datagrid/sorting.md
+++ b/controls/datagrid/sorting.md
@@ -62,7 +62,7 @@ The `DelegateSortDescriptor` exposes the following properties:
 * `KeyLookup`&mdash;Gets or sets the `IKeyLookup` instance that is used to retrieve the sort key for each data item.
 * `SortOrder`&mdash;Gets or sets the order of the sorting (ascending or descending).
 
-To use a `DelegateSortDescriptor`, create a class that implements the `IKeyLookup` interface which will return the key by which you want to sort. Then, add the `DelegateSortDescriptor` to the `RadDataGrid.SortDescriptors` collection and set its `KeyLookUp` property.
+To use a `DelegateSortDescriptor`, create a class that implements the `IKeyLookup` interface which will return the key by which you want to sort. Then, add the `DelegateSortDescriptor` to the `RadDataGrid.SortDescriptors` collection and set its `KeyLookup` property.
 
 The following example demonstrates a custom `IKeyLookup` implementation.
 

--- a/controls/datagrid/theming-and-styles/style-selectors.md
+++ b/controls/datagrid/theming-and-styles/style-selectors.md
@@ -47,11 +47,11 @@ You can set a different style on a group header and footer based on custom style
 
 > For the DataGrid Style Selector example, go to the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) and navigate to the **DataGrid > Styling** category.
 
-The `CellContentStyleSelector`, `CellDecorationStyleSelector`, `RowBackgroundStyleSelector`, `GroupHeaderStyleSelectorand`, and `GroupFooterStyleSelector` use the `SelectStyle` method to change the style.
+The `CellContentStyleSelector`, `CellDecorationStyleSelector`, `RowBackgroundStyleSelector`, `GroupHeaderStyleSelector`, and `GroupFooterStyleSelector` use the `SelectStyle` method to change the style.
 
 ## Example with Cell and Group Style Selectors
 
-The following example demonstrates how to apply the style selectors on the DataGrid cell and group header. You will add the DataGrid and set the `CellContentStyleSelector` property as a static resource of type `MyCellContentStyleSelector`, `CellDecorationStyleSelector` as a static resource of type `MyCellDecorationStyleSelector`, and `GroupStyleSelector` as a static resource of type `MyGroupStyleSelector`:
+The following example demonstrates how to apply the style selectors on the DataGrid cell and group header. You will add the DataGrid and set the `CellContentStyleSelector` property as a static resource of type `MyCellContentStyleSelector`, `CellDecorationStyleSelector` as a static resource of type `MyCellDecorationStyleSelector`, and `GroupHeaderStyleSelector` as a static resource of type `MyGroupSelector`:
 
 **1.** Define the `RadDataGrid` in XAML:
 


### PR DESCRIPTION

## Change Summary

13 factual inaccuracies in the DataGrid docs, all discovered by cross-checking docs against the telerik/maui source:

1. **selection.md** — SelectedItem Row/Cell type mapping was reversed. Row -> business object; Cell -> DataGridCellInfo.
2. **sorting.md** — KeyLookUp typo corrected to KeyLookup.
3. **editing.md** — PickerColumn (does not exist) corrected to DataGridComboBoxColumn; text editor Entry corrected to RadEntry.
4. **columns/overview.md**, **columns/column-types/time-column.md** — DataGridTimeColumn type standardized to TimeSpan (not DateTime).
5. **filtering/overview.md**, **filtering/programmatic-filtering.md** — Collection property name corrected from FilterDescriptor to FilterDescriptors.
6. **filtering/programmatic-filtering.md** — TimeSpanFilterDescriptor example had invalid value 22/11/21; corrected to 22:11:21.
7. **filtering/programmatic-filtering.md** — DistinctValuesFilterDescriptor.Value docs implied scalar; source expects HashSet<object>. Example updated.
8. **commands/overview.md** — ColumnHeaderTap parameter type DataGridTextColumn corrected to DataGridColumn; added missing confirmed command IDs.
9. **theming-and-styles/style-selectors.md** — Fixed GroupHeaderStyleSelectorand typo and incorrect selector class names in example.
10. **columns/resizing.md** — Platform listed as MacOS; corrected to MacCatalyst.
11. **cells/current-cell.md** — CurrentCellChanged described as keyboard-only; broadened to any CurrentCell change.
12. **overview.md** — Empty template described as showing when ItemsSource is null or empty; clarified that default EmptyContentDisplayMode is ItemsSourceNull.
13. **search-as-you-type.md** — Snippet ID scheduler-search-searchstarting-event was a copy-paste from the Scheduler docs; corrected to datagrid-search-searchstarting-event.

## Affected Controls

RadDataGrid (docs only)

## Testing Notes

No automated tests needed. Spot-check SelectedItem behavior with Row vs Cell selection unit, and DataGridTimeColumn binding with TimeSpan properties.

## Breaking Change

Breaking change: No
