### PR TITLE
CollectionView: Fix 17 docs inaccuracies found during source verification

### DIFF
--- a/controls/collectionview/accessibility/keyboard-navigation/maccatalyst.md
+++ b/controls/collectionview/accessibility/keyboard-navigation/maccatalyst.md
@@ -39,5 +39,5 @@ The [Telerik UI for .NET MAUI CollectionView]({%slug collectionview-overview%}) 
 
 ## See Also
 
-- [Keyboard navigation support on MacCatalyst]({%slug collectionview-keyboard-support-mac%})
+- [Keyboard navigation support on WinUI]({%slug collectionview-keyboard-support-winui%})
 - [Screen Reader]({%slug collectionview-accessibility-screen-reader%})

--- a/controls/collectionview/accessibility/screen-reader.md
+++ b/controls/collectionview/accessibility/screen-reader.md
@@ -1,7 +1,7 @@
 ---
 title: Screen Reader
 page_title: .NET MAUI CollectionView Documentation - Screen Reader
-description: The Telerik UI for .NET MAUI CollectionView provides screen reader support for Android and iOS.
+description: The Telerik UI for .NET MAUI CollectionView provides screen reader support for Android, iOS, MacCatalyst, and WinUI.
 position: 0
 slug: collectionview-accessibility-screen-reader
 tags: accessibility, collectionview, screen reader, accessibility support, dotnet maui

--- a/controls/collectionview/commands.md
+++ b/controls/collectionview/commands.md
@@ -49,7 +49,7 @@ This is the result:
 
 <snippet id='collectionview-grouptapcommand-model' />
 
-**2.** Create a `ViewModel` with a command that will be bound to the `RadCollectionView.GroupItemTapCommand`:
+**2.** Create a `ViewModel` with a command that will be bound to the `RadCollectionView.GroupTapCommand`:
 
 <snippet id='collectionview-grouptapcommand-viewmodel' />
 

--- a/controls/collectionview/current-item.md
+++ b/controls/collectionview/current-item.md
@@ -1,7 +1,7 @@
 ---
 title: Current Item
 page_title: .NET MAUI CollectionView Documentation - Current Item
-description: Learn how to set the behavior and style the appearance of the current cell of the Telerik UI for .NET MAUI CollectionView component.
+description: Learn how to set the behavior and style the appearance of the current item of the Telerik UI for .NET MAUI CollectionView component.
 position: 15
 slug: collectionview-current-item
 tags: current item, keyboard navigation, maui, collectionview, dotnet maui

--- a/controls/collectionview/events.md
+++ b/controls/collectionview/events.md
@@ -75,7 +75,7 @@ This is the result for `ItemTapped`:
 
 ![.NET MAUI CollectionView ItemTapped](images/collectionview-item-tapped.gif "Telerik .NET MAUI CollectionView")
 
-> For a runnable example demonstrating the CollectionView `ItemTapped` event or `GroupItemTapped` event, see the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) and go to **CollectionView > Events** category.
+> For a runnable example demonstrating the CollectionView `ItemTapped` event or `GroupTapped` event, see the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) and go to **CollectionView > Events** category.
 
 ## Scrolling Events
 

--- a/controls/collectionview/grouping/header.md
+++ b/controls/collectionview/grouping/header.md
@@ -23,7 +23,7 @@ The `BindingContext` of the `GroupHeader` is a complex object&mdash;`GroupContex
 The CollectionView control for .NET MAUI provides the following styling properties for customizing the appearance of the group view:
 
 * `GroupViewStyle`(`Style` with target type `RadCollectionViewGroupView`)&mdash;Specifies the style applied to the group view.
-* `GroupViewStyleSelector`(`Style` with target type `RadCollectionViewGroupView`)&mdash;Specifies the style selector for the group view.
+* `GroupViewStyleSelector`(`IStyleSelector`)&mdash;Specifies the style selector for the group view.
 
 ## Customizing the Area With the Group Header Text
 

--- a/controls/collectionview/grouping/property-group-descriptor.md
+++ b/controls/collectionview/grouping/property-group-descriptor.md
@@ -1,6 +1,6 @@
 ---
 title: Property Group Descriptor
-page_title: .NET MAUI CollectionView Documentation - Porperty Group Descriptors
+page_title: .NET MAUI CollectionView Documentation - Property Group Descriptors
 description: Try now the Telerik UI for .NET MAUI CollectionView and its PropertyGroupDescriptor option for grouping items by a property value from the class that defines them.
 position: 2
 slug: collectionview-property-group-descriptor

--- a/controls/collectionview/item-swipe/item-swipe-commands.md
+++ b/controls/collectionview/item-swipe/item-swipe-commands.md
@@ -13,7 +13,7 @@ The .NET MAUI CollectionView provides the following commands related to swipe ac
 
 - `SwipeStartingCommand`(`ICommand`)&mdash;Occurs when an item is about to be swiped. The command parameter is of the `CollectionViewSwipeStartingCommandContext` type that provides the following properties:
   - `Item`(`object`)&mdash;The item that will be swiped.
-  - `Cancel`(`bool`)&mdash;If you set this value to `false`, the swiping will be canceled.
+  - `Cancel`(`bool`)&mdash;If you set this value to `true`, the swiping will be canceled.
 - `SwipingCommand`(`ICommand`)&mdash;Occurs while the user is swiping the item. The command parameter is of the `CollectionViewSwipingCommandContext` type that provides the following properties:
   - `Item`(`object`)&mdash;The item that is being swiped.
   - `Offset`(`double`)&mdash;The offset of the swiped item from its initial position.

--- a/controls/collectionview/item-swipe/item-swipe-events.md
+++ b/controls/collectionview/item-swipe/item-swipe-events.md
@@ -13,7 +13,7 @@ The following `RadCollectionView` events are related to the item swiping feature
 
 - `SwipeStarting`&mdash;Occurs when an item is about to be swiped. The event arguments are of the `CollectionViewSwipeStartingEventArgs` type that provides the following properties:
   - `Item`(`object`)&mdash;The item that will be swiped.
-  - `Cancel`(`bool`)&mdash;If you set this value to `false`, the swiping will be canceled.
+  - `Cancel`(`bool`)&mdash;If you set this value to `true`, the swiping will be canceled.
 - `Swiping`&mdash;Occurs while the user is swiping the item. The event arguments are of the `CollectionViewSwipingEventArgs` type that provides the following properties:
   - `Item`(`object`)&mdash;The item that is being swiped.
   - `Offset`(`double`)&mdash;The offset of the swiped item from its initial position.

--- a/controls/collectionview/item-swipe/overview.md
+++ b/controls/collectionview/item-swipe/overview.md
@@ -21,8 +21,8 @@ The following image shows swipe actions revealed on both sides of a CollectionVi
 
 When item swipe is enabled, the user swipes a CollectionView item to expose a template that contains custom content. The swipe direction depends on the CollectionView orientation:
 
-- In a vertically oriented CollectionView, `StartSwipeTemplate` appears on swipe left and `EndSwipeTemplate` appears on swipe right.
-- In a horizontally oriented CollectionView, `StartSwipeTemplate` appears on swipe up and `EndSwipeTemplate` appears on swipe down.
+- In a vertically oriented CollectionView, `StartSwipeTemplate` appears on swipe right and `EndSwipeTemplate` appears on swipe left.
+- In a horizontally oriented CollectionView, `StartSwipeTemplate` appears on swipe down and `EndSwipeTemplate` appears on swipe up.
 
 Use this feature when you want quick item-level actions without opening a separate details screen or context menu.
 
@@ -34,8 +34,8 @@ Use the following `RadCollectionView` properties to configure item swipe:
 - `SwipeThreshold` (`double`)&mdash;Defines the length (in pixels) of the swipe gesture that is required to trigger the feature.
 - `StartSwipeLength` (`double`)&mdash;Defines how far the item moves and remains open when the start swipe template is revealed.
 - `EndSwipeLength` (`double`)&mdash;Defines how far the item moves and remains open when the end swipe template is revealed.
-- `StartSwipeTemplate` (`DataTemplate`)&mdash;Defines the content shown for a swipe left in vertical orientation or a swipe up in horizontal orientation.
-- `EndSwipeTemplate` (`DataTemplate`)&mdash;Defines the content shown for a swipe right in vertical orientation or a swipe down in horizontal orientation.
+- `StartSwipeTemplate` (`DataTemplate`)&mdash;Defines the content shown for a swipe right in vertical orientation or a swipe down in horizontal orientation.
+- `EndSwipeTemplate` (`DataTemplate`)&mdash;Defines the content shown for a swipe left in vertical orientation or a swipe up in horizontal orientation.
 
 If you want different actions on each side, define both swipe templates and set lengths that match the size of the content inside each template.
 

--- a/controls/collectionview/listview-migration.md
+++ b/controls/collectionview/listview-migration.md
@@ -23,7 +23,7 @@ When migrating the Telerik .NET MAUI ListView, consider the following difference
 | Filtering through `DelegateFilterDescriptor` | [Filtering]({%slug collectionview-filtering%}) through various filter descriptors, such as `TextFilterDescriptor`, `NumericalFilterDescriptor`, etc |
 | Header and Footer templates | [Header and Footer templates]({%slug collectionview-header-footer%}) |
 | Load On Demand&mdash;Automatic and Manual, items can be loaded on demand through a `ListViewLoadOnDemandCollection`, a `LoadOnDemand` event or LoadOnDemand `ListViewUserCommand`  | [Load On Demand]({%slug collectionview-load-on-demand%})&mdash;Automatic and Manual, items can be loaded on demand through a `LoadOnDemandCollection`, a `LoadOnDemand` event or `LoadOnDemandCommand` |
-| Scrolling&mdash;`VerticalScrollBarVisibility` property, `ScrollItemIntoView` method | [Scrolling]({%slug collectionview-scrolling%})&mdash;`ScrollItemIntoView` method, `Scrolled` event |
+| Scrolling&mdash;`VerticalScrollBarVisibility` and `HorizontalScrollBarVisibility` properties, `ScrollItemIntoView` method | [Scrolling]({%slug collectionview-scrolling%})&mdash;`VerticalScrollBarVisibility` and `HorizontalScrollBarVisibility` properties, `ScrollItemIntoView` method, `Scrolled` event |
 | Linear and Grid Layouts | [Linear]({%slug collectionview-linear-layout%}) and [Grid]({%slug collectionview-grid-layout%}) Layouts |
 | Cell Swipe with `ItemSwipeContentTemplate` and `SwipeOffset` | [Item Swipe]({%slug collectionview-item-swipe-overview%}) with `StartSwipeTemplate`, `EndSwipeTemplate`, `StartSwipeLength` and `EndSwipeLength` properties |
 | Pull To Refresh built-in funcionality | [Refresh Data functionality]({%slug collectionview-pull-to-refresh%}) through a RefreshView control |

--- a/controls/collectionview/load-on-demand/collection.md
+++ b/controls/collectionview/load-on-demand/collection.md
@@ -9,9 +9,9 @@ tags: loading data, .net maui, maui, collectionview, load data on demand, loadin
 
 # .NET MAUI CollectionView LoadOnDemand Collection
 
-To load items on demand, you can use the `RadCollectionView.LoadOnDemandCollection` and set it as an `ItemsSource` for the `CollectionView`.
+To load items on demand, you can use the `Telerik.Maui.LoadOnDemandCollection<T>` and set it as an `ItemsSource` for the `CollectionView`.
 
-The `LoadOnDemandCollection` is a generic type, so you need to point the type of objects it will contain. The type extends the `ObservableCollection<T>` class and expects a `Func<CancellationToken, IEnumerable>` in the constructor.
+The `Telerik.Maui.LoadOnDemandCollection<T>` is a generic type, so you need to point the type of objects it will contain. The type extends the `ObservableCollection<T>` class and expects a `Func<CancellationToken, IEnumerable>` in the constructor.
 
 ## Example
 
@@ -31,7 +31,7 @@ The following example demonstrates a simple setup that shows how to use the coll
 xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 ```
 
-**4.** Create a `ViewModel` and use the `LoadOnDemandCollection` as a type of the property bound to the `RadCollectionView.ItemsSource`:
+**4.** Create a `ViewModel` and use the `Telerik.Maui.LoadOnDemandCollection<T>` as a type of the property bound to the `RadCollectionView.ItemsSource`:
 
 <snippet id='collectionview-loadondemand-collection-viewmodel' />
 

--- a/controls/collectionview/pull-to-refresh.md
+++ b/controls/collectionview/pull-to-refresh.md
@@ -15,7 +15,7 @@ You can achieve a pull-to-refresh functionality in Telerik .NET MAUI CollectionV
 
 ## Example
 
-The following example demonstrates how to use the .NET MAUI `RefresView` with `RadCollectionView`.
+The following example demonstrates how to use the .NET MAUI `RefreshView` with `RadCollectionView`.
 
 **1.** Define the `RefreshView` and `RadCollectionView` in XAML:
 

--- a/controls/collectionview/scrolling.md
+++ b/controls/collectionview/scrolling.md
@@ -1,7 +1,7 @@
 ---
 title: Scrolling
 page_title: .NET MAUI CollectionView Documentation - Scrolling
-description: Try now the Telerik UI for .NET MAUI CollectionView Scrolling options like the Vertical Scrollbar and programmatic scrolling with the ScrollTo method.
+description: Try now the Telerik UI for .NET MAUI CollectionView Scrolling options like the Vertical Scrollbar and programmatic scrolling with the ScrollItemIntoView method.
 position: 8
 slug: collectionview-scrolling
 tags: programmatic, scrolling, scrollbar
@@ -39,7 +39,7 @@ The following example demonstrates how to scroll to an item in the CollectionVie
 xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 ```
 
-**5.** Button clicked event handler for calling the `ScrollTo` method:
+**5.** Button clicked event handler for calling the `ScrollItemIntoView` method:
 
 <snippet id='collectionview-programmatic-scrolling'/>
 

--- a/controls/collectionview/sorting.md
+++ b/controls/collectionview/sorting.md
@@ -53,7 +53,7 @@ The `DelegateSortDescriptor` exposes the following properties:
 * `KeyLookup`&mdash;Gets or sets the `IKeyLookup` instance that is used to retrieve the sort key for each data item.
 * `SortOrder`&mdash;Gets or sets the order of the sorting (ascending or descending).
 
-To use a `DelegateSortDescriptor`, create a class that implements the `IKeyLookup` interface which will return the key by which you want to sort. Then, add the `DelegateSortDescriptor` to the `RadCollectionView.SortDescriptors` collection and set its `KeyLookUp` property.
+To use a `DelegateSortDescriptor`, create a class that implements the `IKeyLookup` interface which will return the key by which you want to sort. Then, add the `DelegateSortDescriptor` to the `RadCollectionView.SortDescriptors` collection and set its `KeyLookup` property.
 
 
 ## See Also

--- a/controls/collectionview/styling/group-style-selector.md
+++ b/controls/collectionview/styling/group-style-selector.md
@@ -12,7 +12,7 @@ The .NET MAUI CollectionView component exposes a conditional styling feature tha
 
 Apply conditional styling to the group header by setting the following properties:
 
-* `GroupViewStyleSelector` (`Style` with target type `RadCollectionViewGroupView`)&mdash;Specifies the style applied to the group container when grouping is applied.
+* `GroupViewStyleSelector` (`IStyleSelector`)&mdash;Specifies the style selector applied to the group container when grouping is applied.
 
 The following example shows how to use the `GroupViewStyleSelector`:
 

--- a/controls/collectionview/styling/visual-states.md
+++ b/controls/collectionview/styling/visual-states.md
@@ -32,5 +32,5 @@ The CollectionView provides the following `CommonStates` visual states:
 - [Sorting]({%slug collectionview-sorting%})
 - [Selection]({%slug collectionview-selection%})
 - [Commands]({%slug collectionview-commands%})
-- [Events]({%slug collectionview-commands%})
+- [Events]({%slug collectionview-events%})
 


### PR DESCRIPTION


## Change Summary

17 factual inaccuracies in the CollectionView docs, discovered by cross-checking against the telerik/maui source:

1. **commands.md** - GroupItemTapCommand corrected to GroupTapCommand.
2. **events.md** - GroupItemTapped corrected to GroupTapped.
3. **scrolling.md** - ScrollTo method corrected to ScrollItemIntoView(object item, bool animate = true).
4. **sorting.md** - KeyLookUp typo corrected to KeyLookup.
5. **listview-migration.md** - Added missing VerticalScrollBarVisibility and HorizontalScrollBarVisibility to the migration table.
6. **load-on-demand/collection.md** - Type reference corrected to Telerik.Maui.LoadOnDemandCollection<T>.
7. **item-swipe/overview.md** - Swipe direction mapping for StartSwipeTemplate/EndSwipeTemplate was reversed; corrected per source.
8. **item-swipe/item-swipe-events.md** - Cancelling a swipe requires Cancel = true, not Cancel = false.
9. **item-swipe/item-swipe-commands.md** - Same Cancel = true fix for the command context.
10. **grouping/header.md** - GroupViewStyleSelector type corrected from Style to IStyleSelector.
11. **styling/group-style-selector.md** - Same GroupViewStyleSelector type fix.
12. **accessibility/screen-reader.md** - Platform coverage broadened from Android/iOS to include MacCatalyst and WinUI (with AutomationManager note).
13. **current-item.md** - Description said "current cell"; corrected to "current item".
14. **accessibility/keyboard-navigation/maccatalyst.md** - See Also link was self-referencing; corrected to point to the Windows keyboard navigation page.
15. **styling/visual-states.md** - Events See Also link pointed to collectionview-commands; corrected to collectionview-events.
16. **grouping/property-group-descriptor.md** - Frontmatter page_title typo "Porperty" corrected to "Property".
17. **pull-to-refresh.md** - Typo "RefresView" corrected to "RefreshView".

## Affected Controls

RadCollectionView (docs only)

## Testing Notes

No automated tests needed. Key behavioral fixes to spot-check:
- Item swipe cancel: setting Cancel = true in SwipeStarting should prevent the swipe from opening.
- GroupTapCommand / GroupTapped: verify correct property/event names compile against source.

## Breaking Change

Breaking change: No
