### PR TITLE
Buttons: Fix docs inaccuracies in Button, TemplatedButton, and DropDownButton

### DIFF
--- a/controls/button/configuration.md
+++ b/controls/button/configuration.md
@@ -62,7 +62,7 @@ The following image shows the end result.
 
 ## Font Options
 
-The following properties specify the font options that apply to the content when `Content` is `string` and `ContentTemplate` is not set:
+The following properties specify the font options for the `Button.Text`:
 
 * `FontFamily` (`string`)&mdash;Specifies the font family of the `Button.Text`.
 * `FontSize` (`double`)&mdash;Specifies the font size of the `Button.Text` in pixels.

--- a/controls/dropdownbutton/styling.md
+++ b/controls/dropdownbutton/styling.md
@@ -47,6 +47,7 @@ The DropDownButton uses the .NET MAUI Visual State Manager and defines a visual 
 * `FocusedMouseOver`
 * `Pressed`
 * `FocusedPressed`
+* `Focused`
 * `Disabled`
 
 ### Example of Styling the DropDownButton

--- a/controls/dropdownbutton/visual-states.md
+++ b/controls/dropdownbutton/visual-states.md
@@ -22,6 +22,7 @@ The DropDownButton provides the following `CommonStates` visual states:
 | `FocusedPressed` | (Desktop-only) Applies when the button is pressed and focused by using the keyboard. |
 | `MouseOver` | (Desktop-only) Applies when the mouse pointer hovers over the control. |
 | `FocusedMouseOver` | (Desktop-only) Applies when the mouse pointer hovers over the control and the control is focused by using the keyboard. |
+| `Focused` | (Desktop-only) Applies when the button is focused by using the keyboard and the drop-down is closed. |
 | `Disabled` | Applies when the button is disabled. |
 
 ## Using the Visual States

--- a/controls/templatedbutton/accessibility/keyboard-navigation.md
+++ b/controls/templatedbutton/accessibility/keyboard-navigation.md
@@ -14,6 +14,7 @@ The [Telerik UI for .NET MAUI TemplatedButton]({%slug templatedbutton-overview %
 | ------ | ------ |
 | `Tab` | Enters or exits the TemplatedButton. |
 | `Enter` | Makes the TemplatedButton perform a click action. |
+| `Space` | Makes the TemplatedButton perform a click action. |
 
 ## See Also
 


### PR DESCRIPTION
## Change Summary

Fix four discrepancies between the Telerik MAUI source code and the Button, TemplatedButton, and DropDownButton documentation, found by cross-referencing source against docs.

- **`button/configuration.md`** — The Font Options section contained the conditional "when `Content` is `string` and `ContentTemplate` is not set", which belongs to `RadTemplatedButton`. `RadButton` has no `Content` or `ContentTemplate` properties; its font properties apply to `Button.Text` directly and unconditionally. Removed the incorrect conditional.
- **`templatedbutton/accessibility/keyboard-navigation.md`** — The keyboard table listed only `Enter` as the action key. `RadButtonBase.OnKeyDown` handles both `RadKeyboardKey.Space` and `RadKeyboardKey.Enter` on WinUI and MacCatalyst. Added `Space` to the table.
- **`dropdownbutton/visual-states.md`** — The `Focused` visual state was missing from the table. `RadButtonBase.ChangeVisualState()` emits `"Focused"` when the button is keyboard-focused, not open, not pressed, and not hovered. `RadDropDownButton` reaches this state via `base.ChangeVisualState()` when the drop-down is closed.
- **`dropdownbutton/styling.md`** — Added `Focused` to the `CommonStates` VSM list to match the `visual-states.md` update.



## Affected Controls

- None (documentation-only changes)

## Testing Notes

- Verified each fix against `RadButtonBase.cs`, `RadDropDownButton.cs`, and `DropDownButtonConstants.cs` in `telerik/maui`.
- No new automated tests required — these are prose and table corrections.

## Breaking Change

- Breaking change: No

## Release Notes Text

- Not available (no linked work item context).
