### PR TITLE
Fix stale WatermarkText property name in Entry events example

### DIFF
--- a/controls/entry/events.md
+++ b/controls/entry/events.md
@@ -26,14 +26,14 @@ The following example demonstrates the Entry definition in XAML with the `TextCh
 <VerticalStackLayout>
     <telerik:RadEntry x:Name="entry"
                       Keyboard="Numeric"
-                      WatermarkText="Watermark Text"
+                      Placeholder="Enter a number"
                       TextChanged="Entry_TextChanged"
                       Completed="Entry_Completed"/>
     <Label x:Name="textChangedLabel"/>
 </VerticalStackLayout>
  ```
 
-**2.** Set the `TexhChanged` event.
+**2.** Set the `TextChanged` event.
 
 ```C#
 private void Entry_TextChanged(object sender, TextChangedEventArgs e)


### PR DESCRIPTION
## Summary

The XAML snippet in controls/entry/events.md used the old Xamarin property name WatermarkText, which was renamed to Placeholder in the .NET MAUI version. This caused a confusing discrepancy between the events example and the migrate-from-xamarin article.

Also fixed a typo in the section heading: TexhChanged - TextChanged.

## Changes

- Replace WatermarkText with Placeholder in the XAML snippet
- Fix section heading typo: TexhChanged - TextChanged