### PR TITLE
DataGrid/TreeDataGrid: Fix SelectedItem type mapping for Row and Cell SelectionUnit

### DIFF
--- a/controls/datagrid/selection.md
+++ b/controls/datagrid/selection.md
@@ -65,8 +65,8 @@ Once you make a selection, you can get or modify the collection with the selecte
 
 The `SelectedItem` property gets or sets the value of the selected item in the `DataGrid`. The type of the `SelectedItem` depends on the value of the `SelectionUnit`.
 
-* `Row`&mdash;`SelectedItem` is of type `DataGridCellInfo`.
-* `Cell`&mdash;`SelectedItem` is the same type as the business object.
+* `Row`&mdash;`SelectedItem` is the same type as the business object.
+* `Cell`&mdash;`SelectedItem` is of type `DataGridCellInfo`.
 
 ## Events
 

--- a/controls/treedatagrid/selection.md
+++ b/controls/treedatagrid/selection.md
@@ -65,8 +65,8 @@ Once you make a selection, you can get or modify the collection with the selecte
 
 The `SelectedItem` property gets or sets the value of the selected item in the `DataGrid`. The type of the `SelectedItem` depends on the value of the `SelectionUnit`.
 
-* `Row`&mdash;`SelectedItem` is of type `DataGridCellInfo`.
-* `Cell`&mdash;`SelectedItem` is the same type as the business object.
+* `Row`&mdash;`SelectedItem` is the same type as the business object.
+* `Cell`&mdash;`SelectedItem` is of type `DataGridCellInfo`.
 
 ## Events
 


### PR DESCRIPTION
- [x] The change is tested

## Change Summary

- Fixed inverted `SelectedItem` type mapping in the `SelectedItem` bullet list under the `SelectedItems` section.
- For `SelectionUnit = Row`: `SelectedItem` is now correctly documented as the **business object** (data item).
- For `SelectionUnit = Cell`: `SelectedItem` is now correctly documented as `DataGridCellInfo`.
- The preceding sentence in both files already stated the correct mapping ("DataGridCellInfo for a cell and a data item for a row") — the bullet list below it had the two values swapped.
- Fix applied to both `controls/datagrid/selection.md` and `controls/treedatagrid/selection.md`.

## Affected Controls

- `RadDataGrid`
- `RadTreeDataGrid`

## Testing Notes

- No new tests needed — this is a documentation-only fix.
- Verify manually by cross-checking the corrected bullets against the confirmed correct sentence in the same paragraph.

## Breaking Change

- Breaking change: No

## Release Notes Text

- Not available (no linked work item context).
