### PR TITLE
Fix ItemSpacing default value for RadDataPager

### DIFF
--- a/controls/datapager/page-configuration.md
+++ b/controls/datapager/page-configuration.md
@@ -46,7 +46,7 @@ To implement a page number range, use the following DataPager properties:
 
 ## Item Spacing
 
-You can specify the space between the items in the DataPager by setting the `ItemSpacing` (`double`) property. The default value is `16`.
+You can specify the space between the items in the DataPager by setting the `ItemSpacing` (`double`) property. The default value is `0`.
 
 ## Example
 


### PR DESCRIPTION
The documentation states the default value of \ItemSpacing\ is \16\, but the source code declares it as \