### PR TITLE
Chat: Add missing AutoScrollMode.Always enum value to scrolling docs

### DIFF
--- a/controls/chat/scrolling.md
+++ b/controls/chat/scrolling.md
@@ -16,7 +16,8 @@ Use the `AutoScrollMode` (`AutoScrollMode`) property to control whether the Chat
 
 The property supports the following values:
 
-* `Automatic`&mdash;Applies the default behavior. The Chat scrolls automatically when the current user sends a message and when new items are added in scenarios where automatic scrolling should occur.
+* `Automatic`&mdash;Applies the default behavior. The Chat scrolls automatically when the current user sends a message and when new items are received only if the list is already scrolled to the bottom.
+* `Always`&mdash;Scrolls to the new message whenever a message is sent or received, regardless of the current scroll position.
 * `Never`&mdash;Disables automatic scrolling. Use this mode when you need to preserve the current scroll position while appending older or incoming messages.
 
 ## Scroll to Item


### PR DESCRIPTION
## Change Summary

- Add the missing `Always` value to the `AutoScrollMode` enum description in the Chat scrolling documentation.
- The `Always` mode scrolls to the new message on every send or receive, regardless of the current scroll position. It was present in source (`AutoScrollMode.cs`) but absent from the docs.
- The `Automatic` description was also made more precise to clarify the "already at the bottom" condition for incoming messages.

## Affected Controls

- None (docs-only fix).

## Testing Notes

- No code changes. Verify the updated article at `controls/chat/scrolling.md` renders correctly.

## Breaking Change

- Breaking change: No

## Release Notes Text

- Not available (no linked work item context).
