### PR TITLE
Updated code snippet descriptions and image alt

### DIFF
--- a/controls/collectionview/overview.md
+++ b/controls/collectionview/overview.md
@@ -10,7 +10,7 @@ slug: collectionview-overview
 
 The Telerik .NET MAUI CollectionView is a virtualizing view component that provides features associated with scenarios where a list of items is used. The control gives you the option to filter, sort and group the items. Also you can take advantage of the flexible styling API and the exposed templates for customization. 
 
-![.NET MAUI CollectionView Overview](images/collectionview-overview.png "Telerik .NET MAUI CollectionView")
+![Telerik UI for .NET MAUI CollectionView displaying a virtualized list layout with grouped items and styled item cards.](images/collectionview-overview.png "Telerik .NET MAUI CollectionView")
 
 ## Key Features of the .NET MAUI CollectionView
 

--- a/controls/datagrid/aggregates/delegate-aggregate-descriptor.md
+++ b/controls/datagrid/aggregates/delegate-aggregate-descriptor.md
@@ -55,7 +55,7 @@ The following example uses the `DelegateAggregateDescriptor` and a custom implem
 
 The following image shows the end result.
 
-![Delegate Aggregate Descriptor](../images/datagrid-delegate-aggregate-windows.png)
+![.NET MAUI DataGrid DelegateAggregateDescriptor aggregate results example on Windows](../images/datagrid-delegate-aggregate-windows.png)
 
 >important For the DataGrid `DelegateAggregateDescriptor` example refer to the [SDKBrowser Demo application]({%slug sdkbrowser-app%}) and navigate to the **DataGrid > Aggregates** category.
 

--- a/controls/datagrid/aggregates/overview.md
+++ b/controls/datagrid/aggregates/overview.md
@@ -32,7 +32,9 @@ Use the `ShowColumnFooters` property to visualize the [`ColumnFooters`]({%slug d
 
 > The aggregate results are displayed inside the column footer only if there is no `FooterText` set.
 
-![DataGrid Column Footer Aggregate](../images/datagrid-property-aggregate-windows.png)
+**.NET MAUI DataGrid aggregates displayed in the column footer**
+
+![.NET MAUI DataGrid column footer showing aggregate results on Windows](../images/datagrid-property-aggregate-windows.png)
 
 ### Aggregates in Group Header
 
@@ -40,7 +42,9 @@ When [grouping]({%slug datagrid-grouping-overview %}) is applied to the DataGrid
 
 To show the Aggregates in the group header, set the `ShowGroupHeaderAggregates` to `True`.
 
-![DataGrid Group Header Aggregate](../images/datagrid-group-header-aggregate.png)
+**.NET MAUI DataGrid aggregates displayed in the group header**
+
+![.NET MAUI DataGrid group header showing aggregate results for grouped data](../images/datagrid-group-header-aggregate.png)
 
 To align the aggregates in the group according to its header, set the `GroupAggregatesAlignment` (`enum` of type `Telerik.Maui.Controls.DataGrid.DataGridGroupAggregatesAlignment`) property. The available options are:
 
@@ -53,7 +57,9 @@ When [grouping]({%slug datagrid-grouping-overview %}) is applied to the DataGrid
 
 To visualize the group footer, set the `ShowGroupFooters` property to `True`. The group footer is divided into cells which are aligned with the respective columns and show the aggregate results for the particular column.
 
-![DataGrid Group Footer Aggregate](../images/datagrid-group-footer-aggregate.png)
+**.NET MAUI DataGrid aggregates displayed in the group footer**
+
+![.NET MAUI DataGrid group footer showing aggregate results for grouped data](../images/datagrid-group-footer-aggregate.png)
 
 >tip For an outline of all DataGrid features, review the [.NET MAUI DataGrid Overview]({%slug datagrid-overview%}) article.
 

--- a/controls/datagrid/aggregates/overview.md
+++ b/controls/datagrid/aggregates/overview.md
@@ -32,7 +32,7 @@ Use the `ShowColumnFooters` property to visualize the [`ColumnFooters`]({%slug d
 
 > The aggregate results are displayed inside the column footer only if there is no `FooterText` set.
 
-**.NET MAUI DataGrid aggregates displayed in the column footer**
+>caption .NET MAUI DataGrid aggregates displayed in the column footer
 
 ![.NET MAUI DataGrid column footer showing aggregate results on Windows](../images/datagrid-property-aggregate-windows.png)
 
@@ -42,7 +42,7 @@ When [grouping]({%slug datagrid-grouping-overview %}) is applied to the DataGrid
 
 To show the Aggregates in the group header, set the `ShowGroupHeaderAggregates` to `True`.
 
-**.NET MAUI DataGrid aggregates displayed in the group header**
+>caption .NET MAUI DataGrid aggregates displayed in the group header
 
 ![.NET MAUI DataGrid group header showing aggregate results for grouped data](../images/datagrid-group-header-aggregate.png)
 
@@ -57,7 +57,7 @@ When [grouping]({%slug datagrid-grouping-overview %}) is applied to the DataGrid
 
 To visualize the group footer, set the `ShowGroupFooters` property to `True`. The group footer is divided into cells which are aligned with the respective columns and show the aggregate results for the particular column.
 
-**.NET MAUI DataGrid aggregates displayed in the group footer**
+>caption .NET MAUI DataGrid aggregates displayed in the group footer
 
 ![.NET MAUI DataGrid group footer showing aggregate results for grouped data](../images/datagrid-group-footer-aggregate.png)
 

--- a/controls/datagrid/aggregates/property-aggregate-descriptor.md
+++ b/controls/datagrid/aggregates/property-aggregate-descriptor.md
@@ -54,7 +54,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 The following image shows the end result.
 
-![Property Aggregate Descriptor](../images/datagrid-property-aggregate-windows.png)
+![.NET MAUI DataGrid PropertyAggregateDescriptor aggregate results example on Windows](../images/datagrid-property-aggregate-windows.png)
 
 >important For the DataGrid `PropertyAggregateDescriptor` example refer to the [SDKBrowser Demo application]({%slug sdkbrowser-app%}) and navigate to the **DataGrid > Aggregates** category.
 

--- a/controls/datagrid/aggregates/styling.md
+++ b/controls/datagrid/aggregates/styling.md
@@ -159,7 +159,7 @@ The following example demonstrates how to change the style of the column footer 
 
 The following image shows the end result.
 
-![Group Aggregate Style](../images/datagrid-grouping-aggregates.png)
+![.NET MAUI DataGrid group footer aggregate styling example](../images/datagrid-grouping-aggregates.png)
 
 >important For the DataGrid `GroupFooter` styling example refer to the [SDKBrowser Demo application]({%slug sdkbrowser-app%}) and navigate to the **DataGrid > Aggregates** category.
 

--- a/controls/datagrid/cells/current-cell.md
+++ b/controls/datagrid/cells/current-cell.md
@@ -54,7 +54,7 @@ The following example shows the full implementation of the configurations for th
 
 The following image shows the end result.
 
-![DataGrid Current Cell](../images/datagrid-keyboard-navigation.png)
+![.NET MAUI DataGrid current cell styling and navigation example](../images/datagrid-keyboard-navigation.png)
 
 ## Additional Resources
 

--- a/controls/datagrid/cells/mouse-hover-cell.md
+++ b/controls/datagrid/cells/mouse-hover-cell.md
@@ -62,7 +62,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 This is the result:
 
-![.NET MAUI DataGrid Mouse Hover Cell](../images/datagrid-mousehover-cell.gif)
+![.NET MAUI DataGrid mouse hover cell example showing hovered cell highlighting](../images/datagrid-mousehover-cell.gif)
 
 > For the runnable DataGrid Mouse Hover Cell example, see the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) and go to **DataGrid > Cells**.
 

--- a/controls/datagrid/columns/cell-templates.md
+++ b/controls/datagrid/columns/cell-templates.md
@@ -37,7 +37,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 <snippet id='datagrid-club-model' />
 
-**Cell content template in the .NET MAUI DataGrid**
+The following image shows the end result:
 
 ![.NET MAUI DataGrid cell content template example showing custom date and boolean column content](../images/datagrid-column-cell-content-template.png)
 
@@ -63,7 +63,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 <snippet id='datagrid-club-model' />
 
-**Cell edit template in the .NET MAUI DataGrid**
+The following image shows the end result:
 
 ![.NET MAUI DataGrid cell edit template example showing custom boolean column editing controls](../images/datagrid-column-cell-edit-template.png)
 

--- a/controls/datagrid/columns/cell-templates.md
+++ b/controls/datagrid/columns/cell-templates.md
@@ -37,7 +37,9 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 <snippet id='datagrid-club-model' />
 
-![DataGrid Cell Content Template](../images/datagrid-column-cell-content-template.png)
+**Cell content template in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid cell content template example showing custom date and boolean column content](../images/datagrid-column-cell-content-template.png)
 
 ## Cell Edit Template Example
 
@@ -61,7 +63,9 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 <snippet id='datagrid-club-model' />
 
-![DataGrid Cell Edit Template](../images/datagrid-column-cell-edit-template.png)
+**Cell edit template in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid cell edit template example showing custom boolean column editing controls](../images/datagrid-column-cell-edit-template.png)
 
 ## See Also
 

--- a/controls/datagrid/columns/column-types/boolean-column.md
+++ b/controls/datagrid/columns/column-types/boolean-column.md
@@ -6,8 +6,6 @@ position: 2
 slug: datagrid-columns-boolean-column
 ---
 
-# .NET MAUI DataGrid BooleanColumn
-
 The `DataGridBooleanColumn` is used to represent boolean values. It uses the CheckBox control to edit its values in `EditMode`.
 
 ## Important Properties
@@ -34,12 +32,16 @@ The `DataGridBooleanColumn` is used to represent boolean values. It uses the Che
 
 >important `CellContentFormat` uses the format string provided by the framework. For more details, refer to the [`String.Format`](https://docs.microsoft.com/en-us/dotnet/api/system.string.format?view=netframework-4.8) article.
 
+**DataGridBooleanColumn definition**
+
 ```XAML
 <telerik:DataGridBooleanColumn PropertyName="IsChampion"
                                HeaderText="Champion?" />
 ```
 
-![DataGrid Boolean Column](images/booleancolumn-overview.png)
+**Boolean column in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid BooleanColumn displaying boolean values with a checkbox editor](images/booleancolumn-overview.png)
 
 **Example with CellContentTemplate and CellEditTemplate**
 

--- a/controls/datagrid/columns/column-types/boolean-column.md
+++ b/controls/datagrid/columns/column-types/boolean-column.md
@@ -6,6 +6,8 @@ position: 2
 slug: datagrid-columns-boolean-column
 ---
 
+# .NET MAUI DataGrid BooleanColumn
+
 The `DataGridBooleanColumn` is used to represent boolean values. It uses the CheckBox control to edit its values in `EditMode`.
 
 ## Important Properties
@@ -32,18 +34,18 @@ The `DataGridBooleanColumn` is used to represent boolean values. It uses the Che
 
 >important `CellContentFormat` uses the format string provided by the framework. For more details, refer to the [`String.Format`](https://docs.microsoft.com/en-us/dotnet/api/system.string.format?view=netframework-4.8) article.
 
-**DataGridBooleanColumn definition**
+>caption DataGridBooleanColumn definition
 
 ```XAML
 <telerik:DataGridBooleanColumn PropertyName="IsChampion"
                                HeaderText="Champion?" />
 ```
 
-**Boolean column in the .NET MAUI DataGrid**
+>caption Boolean column in the .NET MAUI DataGrid
 
-![.NET MAUI DataGrid BooleanColumn displaying boolean values with a checkbox editor](images/booleancolumn-overview.png)
+![.NET MAUI DataGrid BooleanColumn displaying bool values with a checkbox editor](images/booleancolumn-overview.png)
 
-**Example with CellContentTemplate and CellEditTemplate**
+>caption Example with CellContentTemplate and CellEditTemplate
 
 ```XAML
 <telerik:DataGridBooleanColumn PropertyName="IsChampion" 

--- a/controls/datagrid/columns/column-types/combobox-column.md
+++ b/controls/datagrid/columns/column-types/combobox-column.md
@@ -42,6 +42,8 @@ Here are the specific properties defined for `DataGridComboBoxColumn`:
 
 ## Example
 
+**DataGridComboBoxColumn definition**
+
 ```XAML
 <telerik:DataGridComboBoxColumn PropertyName="Country"
                                 HeaderText="Country"
@@ -49,7 +51,9 @@ Here are the specific properties defined for `DataGridComboBoxColumn`:
                                 ItemsSourcePath="Countries" />
 ```
 
-![DataGrid ComboBox Column](images/pickercolumn-overview.png)
+**ComboBox column in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid ComboBoxColumn displaying a dropdown editor for selecting values](images/pickercolumn-overview.png)
 
 **Example with CellContentTemplate and CellEditTemplate**
 

--- a/controls/datagrid/columns/column-types/combobox-column.md
+++ b/controls/datagrid/columns/column-types/combobox-column.md
@@ -42,7 +42,7 @@ Here are the specific properties defined for `DataGridComboBoxColumn`:
 
 ## Example
 
-**DataGridComboBoxColumn definition**
+>caption DataGridComboBoxColumn definition
 
 ```XAML
 <telerik:DataGridComboBoxColumn PropertyName="Country"
@@ -51,11 +51,11 @@ Here are the specific properties defined for `DataGridComboBoxColumn`:
                                 ItemsSourcePath="Countries" />
 ```
 
-**ComboBox column in the .NET MAUI DataGrid**
+>caption ComboBox column in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid ComboBoxColumn displaying a dropdown editor for selecting values](images/pickercolumn-overview.png)
 
-**Example with CellContentTemplate and CellEditTemplate**
+>caption Example with CellContentTemplate and CellEditTemplate
 
 ```XAML
  <telerik:DataGridComboBoxColumn PropertyName="Country"

--- a/controls/datagrid/columns/column-types/date-column.md
+++ b/controls/datagrid/columns/column-types/date-column.md
@@ -34,13 +34,17 @@ The `DataGridDateColumn` is used to represent `DateTime` objects. It uses the Te
 
 >important `CellContentFormat` uses the format string provided by the framework. For more details, refer to the [Standard Date and Time Formatting](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings) and [Custom Date and Time Formatting](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings) articles.
 
+**DataGridDateColumn definition**
+
 ```XAML
 <telerik:DataGridDateColumn PropertyName="Established"
                             HeaderText="Date Established"
                             CellContentFormat="{}{0: ddd-d-MMM-yyyy}" />
 ```
 
-![DataGrid Date Column](images/datecolumn-overview.png)
+**Date column in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid DateColumn displaying DateTime values with a date picker editor](images/datecolumn-overview.png)
 
 **Example with CellContentTemplate and CellEditTemplate**
 

--- a/controls/datagrid/columns/column-types/date-column.md
+++ b/controls/datagrid/columns/column-types/date-column.md
@@ -34,7 +34,7 @@ The `DataGridDateColumn` is used to represent `DateTime` objects. It uses the Te
 
 >important `CellContentFormat` uses the format string provided by the framework. For more details, refer to the [Standard Date and Time Formatting](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings) and [Custom Date and Time Formatting](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings) articles.
 
-**DataGridDateColumn definition**
+>caption DataGridDateColumn definition
 
 ```XAML
 <telerik:DataGridDateColumn PropertyName="Established"
@@ -46,7 +46,7 @@ The `DataGridDateColumn` is used to represent `DateTime` objects. It uses the Te
 
 ![.NET MAUI DataGrid DateColumn displaying DateTime values with a date picker editor](images/datecolumn-overview.png)
 
-**Example with CellContentTemplate and CellEditTemplate**
+>caption Example with CellContentTemplate and CellEditTemplate
 
 ```XAML
 <telerik:DataGridDateColumn PropertyName="Established" 

--- a/controls/datagrid/columns/column-types/numerical-column.md
+++ b/controls/datagrid/columns/column-types/numerical-column.md
@@ -36,7 +36,7 @@ The `DataGridNumericalColumn` is used to represent only numerical values. It use
 
 ## Example
 
-**DataGridNumericalColumn definition**
+>caption DataGridNumericalColumn definition
 
 ```XAML
 <telerik:DataGridNumericalColumn PropertyName="StadiumCapacity"
@@ -44,11 +44,11 @@ The `DataGridNumericalColumn` is used to represent only numerical values. It use
                                      CellContentFormat=" Seats - {0:D}" />
 ```
 
-**Numerical column in the .NET MAUI DataGrid**
+>caption Numerical column in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid NumericalColumn displaying numeric values with a numeric editor](images/numericalcolumn-overview.png)
 
-**Example with CellContentTemplate and CellEditTemplate**
+>caption Example with CellContentTemplate and CellEditTemplate
 
 ```XAML
 <telerik:DataGridNumericalColumn PropertyName="StadiumCapacity">

--- a/controls/datagrid/columns/column-types/numerical-column.md
+++ b/controls/datagrid/columns/column-types/numerical-column.md
@@ -36,13 +36,17 @@ The `DataGridNumericalColumn` is used to represent only numerical values. It use
 
 ## Example
 
+**DataGridNumericalColumn definition**
+
 ```XAML
 <telerik:DataGridNumericalColumn PropertyName="StadiumCapacity"
                                      HeaderText="Stadium Capacity"
                                      CellContentFormat=" Seats - {0:D}" />
 ```
 
-![DataGrid Numerical Column](images/numericalcolumn-overview.png)
+**Numerical column in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid NumericalColumn displaying numeric values with a numeric editor](images/numericalcolumn-overview.png)
 
 **Example with CellContentTemplate and CellEditTemplate**
 

--- a/controls/datagrid/columns/column-types/template-column.md
+++ b/controls/datagrid/columns/column-types/template-column.md
@@ -94,9 +94,9 @@ Define the DataGrid:
 </telerik:RadDataGrid>
 ```
 
-    **Template column in the .NET MAUI DataGrid**
+>caption Template column in the .NET MAUI DataGrid
 
-    ![.NET MAUI DataGrid TemplateColumn showing custom cell content with sorting and grouping](images/templatecolumn-overview.png)
+![.NET MAUI DataGrid TemplateColumn showing custom cell content with sorting and grouping](images/templatecolumn-overview.png)
 
 ## See Also
 

--- a/controls/datagrid/columns/column-types/template-column.md
+++ b/controls/datagrid/columns/column-types/template-column.md
@@ -94,7 +94,9 @@ Define the DataGrid:
 </telerik:RadDataGrid>
 ```
 
-![DataGrid Template Column](images/templatecolumn-overview.png)
+    **Template column in the .NET MAUI DataGrid**
+
+    ![.NET MAUI DataGrid TemplateColumn showing custom cell content with sorting and grouping](images/templatecolumn-overview.png)
 
 ## See Also
 

--- a/controls/datagrid/columns/column-types/text-column.md
+++ b/controls/datagrid/columns/column-types/text-column.md
@@ -56,11 +56,11 @@ Here is an example how the Text Column properties can be used:
 </telerik:DataGridTextColumn>
 ```
 
-	**Text column in the .NET MAUI DataGrid**
+>caption Text column in the .NET MAUI DataGrid
 
-	![.NET MAUI DataGrid TextColumn displaying string values with entry editing](images/textcolumn-overview.png)
+![.NET MAUI DataGrid TextColumn displaying string values with entry editing](images/textcolumn-overview.png)
 
-**Example with CellContentTemplate and CellEditTemplate**
+>caption Example with CellContentTemplate and CellEditTemplate
 
 ```XAML
 <telerik:DataGridTextColumn PropertyName="Name" 

--- a/controls/datagrid/columns/column-types/text-column.md
+++ b/controls/datagrid/columns/column-types/text-column.md
@@ -56,7 +56,9 @@ Here is an example how the Text Column properties can be used:
 </telerik:DataGridTextColumn>
 ```
 
-![DataGrid Text Column](images/textcolumn-overview.png)
+	**Text column in the .NET MAUI DataGrid**
+
+	![.NET MAUI DataGrid TextColumn displaying string values with entry editing](images/textcolumn-overview.png)
 
 **Example with CellContentTemplate and CellEditTemplate**
 

--- a/controls/datagrid/columns/column-types/time-column.md
+++ b/controls/datagrid/columns/column-types/time-column.md
@@ -34,7 +34,7 @@ The `DataGridTimeColumn` is used to represent `TimeSpan` objects. It uses the Te
 
 >important `CellContentFormat` uses the format string provided by the framework. For more details, refer to the [Standard Date and Time Formatting](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings) and [Custom Date and Time Formatting](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings) articles.
 
-Examples with `CellContentFormat`:
+>caption Examples with `CellContentFormat`:
 
 ```XAML
 <telerik:DataGridTimeColumn PropertyName="Time"
@@ -54,11 +54,11 @@ this.dataGrid.Columns.Add(new DataGridTimeColumn
 });
 ```
 
-**Time column in the .NET MAUI DataGrid**
+>caption mTime column in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid TimeColumn displaying TimeSpan values with a time picker editor](images/timecolumn-overview.png)
 
-**Example with CellContentTemplate and CellEditTemplate**
+>caption Example with CellContentTemplate and CellEditTemplate
 
 ```XAML
 <telerik:DataGridTimeColumn PropertyName="Time" 

--- a/controls/datagrid/columns/column-types/time-column.md
+++ b/controls/datagrid/columns/column-types/time-column.md
@@ -54,7 +54,9 @@ this.dataGrid.Columns.Add(new DataGridTimeColumn
 });
 ```
 
-![DataGrid Time Column](images/timecolumn-overview.png)
+**Time column in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid TimeColumn displaying TimeSpan values with a time picker editor](images/timecolumn-overview.png)
 
 **Example with CellContentTemplate and CellEditTemplate**
 

--- a/controls/datagrid/columns/column-types/toggle-column.md
+++ b/controls/datagrid/columns/column-types/toggle-column.md
@@ -10,7 +10,9 @@ slug: datagrid-columns-toggle-column
 
 The `DataGridToggleRowDetailsColumn` represents `DataGridColumn` that allows the user to show and hide the row details for an item.
 
-![DataGrid Toggle Row Details Column](images/datagrid-row-details.gif)
+**Toggle row details column in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid ToggleRowDetailsColumn showing expandable row details](images/datagrid-row-details.gif)
 
 ## Important Properties
 

--- a/controls/datagrid/columns/column-types/toggle-column.md
+++ b/controls/datagrid/columns/column-types/toggle-column.md
@@ -10,7 +10,7 @@ slug: datagrid-columns-toggle-column
 
 The `DataGridToggleRowDetailsColumn` represents `DataGridColumn` that allows the user to show and hide the row details for an item.
 
-**Toggle row details column in the .NET MAUI DataGrid**
+>caption Toggle row details column in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid ToggleRowDetailsColumn showing expandable row details](images/datagrid-row-details.gif)
 

--- a/controls/datagrid/columns/footer.md
+++ b/controls/datagrid/columns/footer.md
@@ -12,7 +12,9 @@ slug: datagrid-column-footer
 
 The [Telerik UI for .NET MAUI DataGrid]({%slug datagrid-overview%}) allows you to display additional information which applies to the columns in a specific row placed at the bottom of the control. This row consists of individual footer cells for each column.
 
-![.NET MAUI DataGrid Column Footer](../images/column-footer.png)
+**Column footer in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid showing column footer cells](../images/column-footer.png)
 
 By default, column footers are hidden, and, to make them visible, you have to set the `ShowColumnFooters` property to `True`.
 
@@ -60,7 +62,9 @@ Define the `FooterContentTemplate` in the `DataGridColumn`:
 
 <snippet id='datagrid-headerfootercontenttemplate' />
 
-![.NET MAUI DataGrid Column Footer Template](../images/footer-content-template.png)
+**Column footer content template in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid showing a customized column footer content template](../images/footer-content-template.png)
 
 ## See Also
 

--- a/controls/datagrid/columns/footer.md
+++ b/controls/datagrid/columns/footer.md
@@ -12,7 +12,7 @@ slug: datagrid-column-footer
 
 The [Telerik UI for .NET MAUI DataGrid]({%slug datagrid-overview%}) allows you to display additional information which applies to the columns in a specific row placed at the bottom of the control. This row consists of individual footer cells for each column.
 
-**Column footer in the .NET MAUI DataGrid**
+>caption Column footer in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid showing column footer cells](../images/column-footer.png)
 
@@ -62,7 +62,7 @@ Define the `FooterContentTemplate` in the `DataGridColumn`:
 
 <snippet id='datagrid-headerfootercontenttemplate' />
 
-**Column footer content template in the .NET MAUI DataGrid**
+The following image shows the end result:
 
 ![.NET MAUI DataGrid showing a customized column footer content template](../images/footer-content-template.png)
 

--- a/controls/datagrid/columns/frozen-columns.md
+++ b/controls/datagrid/columns/frozen-columns.md
@@ -12,7 +12,9 @@ This article describes the frozen columns feature that the [.NET MAUI DataGrid](
 
 You can pin a column on the left side of the grid by setting the `IsFrozen`(`bool`) property to the column. By default the value is `False`. When setting it to `True` to a concrete column, it makes the column frozen. 
 
-![.NET MAUI DataGrid Frozen Column](../images/frozen-column.gif)
+**Frozen column in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid showing a frozen column while horizontal scrolling](../images/frozen-column.gif)
 
 Set the column freeze in XAML
 
@@ -42,7 +44,7 @@ In a scenario with frozen columns and grouping, you can specify whether the grou
 
 Here is the result when the `AreGroupHeadersClippedWhenFrozen` property is set:
 
-![.NET MAUI DataGrid Frozen Columns and Group Headers](images/frozen-columns-group-headers.gif)
+![.NET MAUI DataGrid showing frozen columns with clipped group headers](images/frozen-columns-group-headers.gif)
 
 ## Styling
 
@@ -65,7 +67,9 @@ Style the splitter UI's `Width`, `BackgroundColor`, `BorderColor` and `BorderThi
 </telerik:RadDataGrid.FrozenColumnsSplitterStyle>
 ```
 
-![.NET MAUI DataGrid Frozen Column](../images/frozen-column-style.png)
+**Frozen columns splitter styling in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid showing a styled frozen columns splitter](../images/frozen-column-style.png)
 
 
 ## See Also

--- a/controls/datagrid/columns/frozen-columns.md
+++ b/controls/datagrid/columns/frozen-columns.md
@@ -54,7 +54,7 @@ You can style the frozen splitter UI using the `FrozenColumnsSplitterStyle`(`Tel
 
 Style the splitter UI's `Width`, `BackgroundColor`, `BorderColor` and `BorderThickness`. 
 
-**Example for `FrozenColumnsSplitterStyle`**
+>caption Example for `FrozenColumnsSplitterStyle`
 
 ```XAML
 <telerik:RadDataGrid.FrozenColumnsSplitterStyle>
@@ -67,7 +67,7 @@ Style the splitter UI's `Width`, `BackgroundColor`, `BorderColor` and `BorderThi
 </telerik:RadDataGrid.FrozenColumnsSplitterStyle>
 ```
 
-**Frozen columns splitter styling in the .NET MAUI DataGrid**
+>caption Frozen columns splitter styling in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid showing a styled frozen columns splitter](../images/frozen-column-style.png)
 

--- a/controls/datagrid/columns/header.md
+++ b/controls/datagrid/columns/header.md
@@ -12,7 +12,7 @@ slug: datagrid-column-header
 
 This article describes how to customize and use column headers when performing different data operations. Column headers are always visible by default. You can further customize them by using the `HeaderStyle` property.
 
-**Column headers in the .NET MAUI DataGrid**
+>caption Column headers in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid showing column headers](../images/column-header.png)
 
@@ -76,7 +76,7 @@ Define the `HeaderContentTemplate` in the DataGrid column:
 
 <snippet id='datagrid-headerfootercontenttemplate' />
 
-**Header content template in the .NET MAUI DataGrid**
+This is the result:
 
 ![.NET MAUI DataGrid showing a customized column header content template](../images/header-content-template.png)
 

--- a/controls/datagrid/columns/header.md
+++ b/controls/datagrid/columns/header.md
@@ -12,7 +12,9 @@ slug: datagrid-column-header
 
 This article describes how to customize and use column headers when performing different data operations. Column headers are always visible by default. You can further customize them by using the `HeaderStyle` property.
 
-![DataGrid Column Header](../images/column-header.png)
+**Column headers in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid showing column headers](../images/column-header.png)
 
 ## Headers Visibility
 
@@ -42,7 +44,7 @@ To customize text inside the header you have to use the `HeaderText` property. T
 
 The user of the application can sort a particular column when tapping on its header. When the data is sorted by a column, the sort indicator shows in the header.
 
-![.NET MAUI DataGrid Column Header Sorting indicator](../images/column-header-sorting.png)
+![.NET MAUI DataGrid column header showing a sorting indicator](../images/column-header-sorting.png)
 
 To learn more about the sorting functionality of the [.NET MAUI DataGrid]({%slug datagrid-overview%}) take a look at the [Sorting]({%slug datagrid-sorting-overview%}) article.
 
@@ -50,7 +52,7 @@ To learn more about the sorting functionality of the [.NET MAUI DataGrid]({%slug
 
 The header of the column hosts the built-in filtering mechanism (the filter indicator which opens the Filtering UI), which allows the user to filter the data by the columns' values.
 
-![.NET MAUI DataGrid Column Header filter indicator](../images/column-header-filtering.png)
+![.NET MAUI DataGrid column header showing a filter indicator](../images/column-header-filtering.png)
 
 To learn more about the filtering functionality take a look at the [Filtering]({%slug datagrid-filtering-overview%}) article.
 
@@ -74,7 +76,9 @@ Define the `HeaderContentTemplate` in the DataGrid column:
 
 <snippet id='datagrid-headerfootercontenttemplate' />
 
-![.NET MAUI DataGrid Column Header Template](../images/header-content-template.png)
+**Header content template in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid showing a customized column header content template](../images/header-content-template.png)
 
 ## Color on Hover
 
@@ -104,7 +108,7 @@ The following example demonstrates how to apply the `BackgroundColor` property t
 
 This is the result:
 
-![DataGrid Header Column Background Color](../columns/images/datagrid-hover-background-color.gif)
+![.NET MAUI DataGrid column header hover state with custom background color](../columns/images/datagrid-hover-background-color.gif)
 
 ## See Also
 

--- a/controls/datagrid/columns/nested-properties.md
+++ b/controls/datagrid/columns/nested-properties.md
@@ -50,7 +50,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 Here is how the DataGrid looks:
 
-![DataGrid Nested Properties](../images/datagrid-nested-properties.png)
+![.NET MAUI DataGrid showing columns bound to nested properties](../images/datagrid-nested-properties.png)
 
 ## See Also
 

--- a/controls/datagrid/columns/overview.md
+++ b/controls/datagrid/columns/overview.md
@@ -86,7 +86,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 Check the result in the image below:
 
-![Telerik .NET MAUI DataGrid Defining Columns](images/datagrid-columns.png)
+![.NET MAUI DataGrid showing manually defined columns with different column types](images/datagrid-columns.png)
 
 > For a runnable example with the DataGrid columns, see the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) and go to the **DataGrid > Columns** category.
 

--- a/controls/datagrid/columns/reordering.md
+++ b/controls/datagrid/columns/reordering.md
@@ -10,7 +10,7 @@ slug: datagrid-columns-reordering
 
 The [.NET MAUI DataGrid]({%slug datagrid-overview%}) exposes a reordering feature allowing the user to drag and drop columns and change their order.
 
-**Columns reordering in the .NET MAUI DataGrid on desktop**
+>caption Columns reordering in the .NET MAUI DataGrid on desktop
 
 ![.NET MAUI DataGrid showing drag-and-drop column reordering on desktop](../images/datagrid-reordering-mac.gif)
 

--- a/controls/datagrid/columns/reordering.md
+++ b/controls/datagrid/columns/reordering.md
@@ -10,7 +10,9 @@ slug: datagrid-columns-reordering
 
 The [.NET MAUI DataGrid]({%slug datagrid-overview%}) exposes a reordering feature allowing the user to drag and drop columns and change their order.
 
-![DataGrid Reordering Desktop](../images/datagrid-reordering-mac.gif)
+**Columns reordering in the .NET MAUI DataGrid on desktop**
+
+![.NET MAUI DataGrid showing drag-and-drop column reordering on desktop](../images/datagrid-reordering-mac.gif)
 
 The following properties are related to the reordering feature:
 
@@ -84,7 +86,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 The result on mobile:
 
-![DataGrid Reordering Phone](../images/datagrid-reordering-winui.gif)
+![.NET MAUI DataGrid showing column reordering on mobile](../images/datagrid-reordering-winui.gif)
 
 ## Example with Indicator Template when Reordering Columns
 
@@ -122,7 +124,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 The result on mobile:
 
-![DataGrid Reordering Indicator Phone](../images/datagrid-reordering-indicator.gif)
+![.NET MAUI DataGrid showing a custom column reordering indicator on mobile](../images/datagrid-reordering-indicator.gif)
 
 > For the runnable DataGrid Drag Templates example, see the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) and go to **DataGrid > Columns**.
 

--- a/controls/datagrid/columns/resizing.md
+++ b/controls/datagrid/columns/resizing.md
@@ -14,7 +14,7 @@ On `WinUI` and `MacCatalyst`, you can change the column width by positioning the
 
 ![.NET MAUI DataGrid showing column resizing on desktop](../images/column-resizing.png)
 
-**Column Resizing on `MacCatalyst`**
+>caption Column Resizing on `MacCatalyst`
 
 ![.NET MAUI DataGrid showing column resizing on MacCatalyst](../images/column-resizing-mac.gif)
 
@@ -47,7 +47,7 @@ To disable the resizing on a specific column, set the `IsResizable` property. Th
                                  IsResizable="False"/>
 ```
 
-**Disabled column resizing in the .NET MAUI DataGrid**
+This is the result:
 
 ![.NET MAUI DataGrid showing a column with resizing disabled](../images/column-resizing-disable-column-level.gif)
 

--- a/controls/datagrid/columns/resizing.md
+++ b/controls/datagrid/columns/resizing.md
@@ -12,11 +12,11 @@ Columns inside the [Telerik UI for .NET MAUI DataGrid]({%slug datagrid-overview%
 
 On `WinUI` and `MacCatalyst`, you can change the column width by positioning the mouse over the column's vertical grid line (in the column header) and dragging it until the desired size is achieved.
 
-![DataGrid Column Resizing](../images/column-resizing.png)
+![.NET MAUI DataGrid showing column resizing on desktop](../images/column-resizing.png)
 
 **Column Resizing on `MacCatalyst`**
 
-![DataGrid Column Resizing](../images/column-resizing-mac.gif)
+![.NET MAUI DataGrid showing column resizing on MacCatalyst](../images/column-resizing-mac.gif)
 
 To resize a column programmatically, you can use the columns `Width` property. For more details review the [Columns Width]({%slug datagrid-columns-width%}) article.
 
@@ -47,7 +47,9 @@ To disable the resizing on a specific column, set the `IsResizable` property. Th
                                  IsResizable="False"/>
 ```
 
-![.NET MAUI DataGrid disable column resizing](../images/column-resizing-disable-column-level.gif)
+**Disabled column resizing in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid showing a column with resizing disabled](../images/column-resizing-disable-column-level.gif)
 
 ## Events
 
@@ -83,7 +85,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 This is the result:
 
-![.NET MAUI DataGrid Resizing event](../images/datagrid-resizing-event.gif)
+![.NET MAUI DataGrid showing the column resizing completed event result](../images/datagrid-resizing-event.gif)
 
 ## See Also
 

--- a/controls/datagrid/columns/skiasharp-cell-renderer.md
+++ b/controls/datagrid/columns/skiasharp-cell-renderer.md
@@ -52,7 +52,7 @@ Check below an example on how to add a `BulletGraph` control as the content of a
 
 Here is the result:
 
-![Telerik .NET MAUI DataGrid SkiaSharp Cell Renderer](images/datagrid-custom-cellrenderer.png)
+![.NET MAUI DataGrid showing a custom SkiaSharp cell renderer with a bullet graph](images/datagrid-custom-cellrenderer.png)
 
 ## See Also
 - [Render Mode]({%slug datagrid-render-mode%})

--- a/controls/datagrid/filtering/filter-control-template.md
+++ b/controls/datagrid/filtering/filter-control-template.md
@@ -51,7 +51,7 @@ The example below shows how to apply the `DataGridTextFilterControl` as a `Filte
 
 Here is the `DataGridTextFilterControl` with the match case properties applied:
 
-![Telerik .NET MAUI DataGrid TextFilterControl](images/datagrid-textfiltercontrol.png)
+![.NET MAUI DataGrid TextFilterControl showing match case options in the filtering UI](images/datagrid-textfiltercontrol.png)
 
 In addition, you can hide the toggle buttons for matching the case with the following implicit style:
 
@@ -79,7 +79,7 @@ Check a quick example on how to create a custom `FilterControlTemplate` below.
 
 Check the result below:
 
-![Telerik .NET MAUI DataGrid Custom Filter Control Template](images/datagrid-customfiltertemplate.gif)
+![.NET MAUI DataGrid showing a custom filter control template in the filtering UI](images/datagrid-customfiltertemplate.gif)
 
 ## See Also
 

--- a/controls/datagrid/filtering/filtering-ui.md
+++ b/controls/datagrid/filtering/filtering-ui.md
@@ -10,7 +10,7 @@ slug: datagrid-filtering-ui
 
 The [.NET MAUI DataGrid]({%slug datagrid-overview%}) provides you with a built-in filtering functionality, which allows the user to filter the data by one or more columns by clicking on the filtering icon next to the header text.
 
-![Filtering UI](../filtering/images/datagrid-filtering-ui.gif)
+![.NET MAUI DataGrid filtering UI opened from a column header filter icon](../filtering/images/datagrid-filtering-ui.gif)
 
 > The Filtering UI appears when clicking the filtering icon in each column's header.
 

--- a/controls/datagrid/getting-started.md
+++ b/controls/datagrid/getting-started.md
@@ -12,7 +12,7 @@ This guide provides the information you need to start using the [Telerik UI for 
 
 At the end, you will achieve the following result.
 
-![Telerik UI for .NET MAUI DataGrid displaying sample country and capital data in the getting started example](images/datagrid-getting-started.png)
+![Telerik UI for .NET MAUI DataGrid getting started example with sample data](images/datagrid-getting-started.png)
 
 ## Prerequisites
 

--- a/controls/datagrid/getting-started.md
+++ b/controls/datagrid/getting-started.md
@@ -12,7 +12,7 @@ This guide provides the information you need to start using the [Telerik UI for 
 
 At the end, you will achieve the following result.
 
-![.NET MAUI DataGrid Getting Started](images/datagrid-getting-started.png)
+![Telerik UI for .NET MAUI DataGrid displaying sample country and capital data in the getting started example](images/datagrid-getting-started.png)
 
 ## Prerequisites
 

--- a/controls/datagrid/grouping/delegate-group-descriptor.md
+++ b/controls/datagrid/grouping/delegate-group-descriptor.md
@@ -28,4 +28,4 @@ Add it to the `GroupDescriptors` collection of the `RadDataGrid` instance:
 
 Here is how the [.NET MAUI DataGrid]({%slug datagrid-overview%}) looks when is grouped through a `DelegateGroupDescriptor`:
 
-![DataGrid Delegate GroupDescriptor](../images/datagrid-delegate-group-descriptor.png)
+![.NET MAUI DataGrid grouped with a DelegateGroupDescriptor using a custom group key](../images/datagrid-delegate-group-descriptor.png)

--- a/controls/datagrid/grouping/group-header-template.md
+++ b/controls/datagrid/grouping/group-header-template.md
@@ -39,7 +39,7 @@ The following example demonstrates how to apply a sample `GroupHeaderTemplate` t
 
 Check the result at the image below:
 
-![Telerik .NET MAUI DataGrid Group Header Template](../images/datagrid-grouping-groupheadertemplate.png)
+![.NET MAUI DataGrid showing a custom group header template for grouped rows](../images/datagrid-grouping-groupheadertemplate.png)
 
 ## See Also
 

--- a/controls/datagrid/grouping/grouping-ui.md
+++ b/controls/datagrid/grouping/grouping-ui.md
@@ -14,7 +14,7 @@ The **DataGrid Grouping UI** exposes the `DataGridServicePanel` view which conta
 
 > The user can drag more than one column into the panel.
 
-**Grouping UI in the .NET MAUI DataGrid**
+>caption Grouping UI in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid grouping UI showing drag-and-drop grouping in the grouping panel](../images/datagrid-grouping-ui.gif)
 

--- a/controls/datagrid/grouping/grouping-ui.md
+++ b/controls/datagrid/grouping/grouping-ui.md
@@ -8,13 +8,15 @@ slug: datagrid-grouping-ui
 
 # .NET MAUI DataGrid Grouping UI
 
-![Grouping UI](../images/datagrid-grouping-ui.gif)
-
 The [Telerik UI for .NET MAUI DataGrid]({%slug datagrid-overview%}) provides a built-in grouping functionality, which allows the user to easily group the data by one or more columns.
 
 The **DataGrid Grouping UI** exposes the `DataGridServicePanel` view which contains the `DataGridGroupingPanel` in itself. To group data, the user has to drag the desired column header to the `DataGridGroupingPanel` located at the top of the DataGrid.
 
 > The user can drag more than one column into the panel.
+
+**Grouping UI in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid grouping UI showing drag-and-drop grouping in the grouping panel](../images/datagrid-grouping-ui.gif)
 
 ## Configuration
 

--- a/controls/datagrid/grouping/overview.md
+++ b/controls/datagrid/grouping/overview.md
@@ -12,11 +12,13 @@ The [Telerik UI for .NET MAUI DataGrid]({%slug datagrid-overview%}) supports gro
 
 ## Grouping UI
 
-![Grouping UI](../images/datagrid-grouping-ui.gif)
-
 The DataGrid Grouping UI is enabled by design on desktop and disabled on mobile, it allows the user to group the DataGrid by dragging and dropping the column headers to the `DataGridGroupingPanel`. 
 
 The UI is represented by the `DataGridGroupingPanel`. The panel is part of the DataGrid and it's visualized at the top.
+
+**Grouping UI in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid grouping UI showing drag-and-drop grouping in the grouping panel](../images/datagrid-grouping-ui.gif)
 
 > For more information about Grouping UI review the [Grouping UI]({%slug datagrid-grouping-ui%}) article of the DataGrid.
 

--- a/controls/datagrid/grouping/overview.md
+++ b/controls/datagrid/grouping/overview.md
@@ -16,7 +16,7 @@ The DataGrid Grouping UI is enabled by design on desktop and disabled on mobile,
 
 The UI is represented by the `DataGridGroupingPanel`. The panel is part of the DataGrid and it's visualized at the top.
 
-**Grouping UI in the .NET MAUI DataGrid**
+>caption Grouping UI in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid grouping UI showing drag-and-drop grouping in the grouping panel](../images/datagrid-grouping-ui.gif)
 

--- a/controls/datagrid/grouping/property-group-descriptor.md
+++ b/controls/datagrid/grouping/property-group-descriptor.md
@@ -38,7 +38,7 @@ Apply the `PropertyGroupDescriptor`:
 
 Here is how the DataGrid looks when it's grouped:
 
-![DataGrid Property GroupDescriptor](../images/datagrid-property-group-descriptor.png)
+![.NET MAUI DataGrid grouped with a PropertyGroupDescriptor using a model property](../images/datagrid-property-group-descriptor.png)
 
 ## See Also
 

--- a/controls/datagrid/load-on-demand.md
+++ b/controls/datagrid/load-on-demand.md
@@ -82,7 +82,7 @@ You have to set it to the `LoadOnDemandRowStyle` property of the DataGrid:
 
 >caption Row appearance after setting the `LoadOnDemandRowStyle` property
 
-![.NET MAUI DataGrid LoadOnDemand Row Style](images/datagrid-rowstyle.png)
+![Telerik UI for .NET MAUI DataGrid load on demand row with a customized Load More button style](images/datagrid-rowstyle.png)
 
 ### Load-More-Button Row Template
 
@@ -98,7 +98,7 @@ The following example shows how to set the property:
 
 >caption Row appearance after setting the `LoadOnDemandRowTemplate`
 
-![.NET MAUI DataGrid LoadOnDemand Row Style](images/datagrid-rowtemplate.png)
+![Telerik UI for .NET MAUI DataGrid load on demand row with a customized Load More button template](images/datagrid-rowtemplate.png)
 
 ## Additional Resources
 - [.NET MAUI DataGrid Product Page](https://www.telerik.com/maui-ui/datagrid)

--- a/controls/datagrid/paging.md
+++ b/controls/datagrid/paging.md
@@ -11,7 +11,7 @@ slug: datagrid-paging
 
 You can page the data of the Telerik UI for .NET MAUI DataGrid by using the [DataPager]({%slug datapager-overview%}) control.
 
-![Telerik UI for .NET MAUI DataGrid integrated with the DataPager control to show paged records and navigation buttons.](images/datapager-datagrid-paging.png)
+![.NET MAUI DataGrid integrated with the DataPager for displaying paged records.](images/datapager-datagrid-paging.png)
 
 >Currently, the DataPager does not support the DataGrid `LoadOnDemand` collection.
 

--- a/controls/datagrid/paging.md
+++ b/controls/datagrid/paging.md
@@ -11,7 +11,7 @@ slug: datagrid-paging
 
 You can page the data of the Telerik UI for .NET MAUI DataGrid by using the [DataPager]({%slug datapager-overview%}) control.
 
-![.NET MAUI DataGrid Paging support](images/datapager-datagrid-paging.png)
+![Telerik UI for .NET MAUI DataGrid integrated with the DataPager control to show paged records and navigation buttons.](images/datapager-datagrid-paging.png)
 
 >Currently, the DataPager does not support the DataGrid `LoadOnDemand` collection.
 

--- a/controls/datagrid/populating-with-data/dynamic-data.md
+++ b/controls/datagrid/populating-with-data/dynamic-data.md
@@ -52,7 +52,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 This is the result:
 
-![Telerik UI for .NET MAUI DataGrid DynamicObject](../images/datagrid-dynamicobject.png)
+![.NET MAUI DataGrid bound to a DynamicObject data source](../images/datagrid-dynamicobject.png)
 
 ## Binding to ExpandoObject
 
@@ -72,7 +72,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 This is the result:
 
-![Telerik UI for .NET MAUI DataGrid ExpandoObject](../images/datagrid-expandoobject.png)
+![.NET MAUI DataGrid bound to an ExpandoObject data source](../images/datagrid-expandoobject.png)
 
 ## Additional Resources
 

--- a/controls/datagrid/row-details/row-details-overview.md
+++ b/controls/datagrid/row-details/row-details-overview.md
@@ -10,7 +10,7 @@ slug: datagrid-row-details-overview
 
 The [Telerik UI for .NET MAUI DataGrid]({%slug datagrid-overview%}) control is capable of presenting additional information through the Row Details functionality. The Row Details is a Data Template defined on the grid or row level and is used for displaying data without affecting the dimensions of the row and the cells within it.
 
-![DataGrid Row Details Overview](images/datagrid-row-details.png)
+![.NET MAUI DataGrid showing expanded row details content](images/datagrid-row-details.png)
 
 To show the Row Details, you can use the following exposed options:
 

--- a/controls/datagrid/row-details/row-details-template.md
+++ b/controls/datagrid/row-details/row-details-template.md
@@ -36,7 +36,7 @@ The following example shows how to define the `RowDetailsTemplate` property in t
 
 The image below illustrates the result from the code snippets:
 
-![DataGrid RowDetailsTemplate](../row-details/images/datagrid-rowdetails-template.png)
+![.NET MAUI DataGrid showing a custom row details template](../row-details/images/datagrid-rowdetails-template.png)
 
 
 ## See Also

--- a/controls/datagrid/row-height.md
+++ b/controls/datagrid/row-height.md
@@ -24,7 +24,7 @@ To set the row height, apply the `RowHeight` property of type `double` to the Da
 
 The following image shows the difference in the way the DataGrid is rendered with and without `RowHeight` specifically set:
 
-![.NET MAUI DataGrid RowHeight](images/datagrid-row-height.png)
+![Telerik UI for .NET MAUI DataGrid comparing default row height with a custom RowHeight setting applied.](images/datagrid-row-height.png)
 
 ## Styling the Row
 

--- a/controls/datagrid/smart-ai-features/ai-assistant/configuration.md
+++ b/controls/datagrid/smart-ai-features/ai-assistant/configuration.md
@@ -74,7 +74,7 @@ Here is an example of how to configure the AI Smart Assistant  settings in the .
 
 <snippet id='datagrid-prompt-load-sample-data-call' />
 
-**AI Smart Assistant configuration in the .NET MAUI DataGrid**
+This is how the AI Smart Assistant configuration in the .NET MAUI DataGrid looks:
 
 ![.NET MAUI DataGrid AI Smart Assistant showing configured prompts and settings](images/datagrid-configuration.gif)
 

--- a/controls/datagrid/smart-ai-features/ai-assistant/configuration.md
+++ b/controls/datagrid/smart-ai-features/ai-assistant/configuration.md
@@ -14,7 +14,7 @@ This article provides information on how to configure the AI Smart Assistant fun
 
 @[template](/_contentTemplates/controls/ai-data-operations.md#ai-smart-assistant-settings)
 
-![MAUI DataGrid empty Prompts View](images/datagrid-empty-view.png)
+![.NET MAUI DataGrid AI Smart Assistant showing the empty prompts view](images/datagrid-empty-view.png)
 
 ## Events
 
@@ -74,7 +74,9 @@ Here is an example of how to configure the AI Smart Assistant  settings in the .
 
 <snippet id='datagrid-prompt-load-sample-data-call' />
 
-![.NET MAUI DataGrid Configuration AI Assistant](images/datagrid-configuration.gif)
+**AI Smart Assistant configuration in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid AI Smart Assistant showing configured prompts and settings](images/datagrid-configuration.gif)
 
 >important The DataGrid AI Smart Assistant examples in the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) use a Telerik-hosted AI service for demonstration purposes only. 
 >

--- a/controls/datagrid/smart-ai-features/ai-assistant/overview.md
+++ b/controls/datagrid/smart-ai-features/ai-assistant/overview.md
@@ -14,11 +14,11 @@ On mobile, the AI Smart Assistant panel can be accessed via a floating action bu
 
 Here is how the AI Smart Assistant panel is arranged on desktop, with the panel above the DataGrid header area, and on mobile, where it is opened from a floating action button in the bottom-right corner of the DataGrid:
 
-![.NET MAUI DataGrid AI Smart Assistant Panel](images/datagrid-ai-prompt-overview.png)
+![.NET MAUI DataGrid AI Smart Assistant panel shown above the header on desktop and opened from a floating action button on mobile](images/datagrid-ai-prompt-overview.png)
 
 Here is how the AI Smart Assistant panel behaves on desktop and mobile when no suggestions are shown:
 
-![.NET MAUI DataGrid AI Smart Assistant Panel](images/datagrid-ai-prompt-panel.png)
+![.NET MAUI DataGrid AI Smart Assistant panel showing only the prompt input area without suggestions](images/datagrid-ai-prompt-panel.png)
 
 > When no suggestions are available, the AI Smart Assistant panel shows only the prompt input area and any configured helper text, without a suggestions list.
 

--- a/controls/datagrid/smart-ai-features/ai-assistant/styling.md
+++ b/controls/datagrid/smart-ai-features/ai-assistant/styling.md
@@ -10,7 +10,7 @@ slug: datagrid-ai-prompt-styling
 
 The .NET MAUI DataGrid control allows you to customize the appearance of the AI Smart Assistant feature to match your application's design requirements. You can modify various visual aspects of the AI Smart Assistant panel, including colors, fonts, and layout.
 
-**AI Smart Assistant styling in the .NET MAUI DataGrid**
+>caption AI Smart Assistant styling in the .NET MAUI DataGrid
 
 ![.NET MAUI DataGrid AI Smart Assistant showing custom styling for the panel and prompts](images/datagrid-ai-smart-assistant-styling.png)
 

--- a/controls/datagrid/smart-ai-features/ai-assistant/styling.md
+++ b/controls/datagrid/smart-ai-features/ai-assistant/styling.md
@@ -10,7 +10,9 @@ slug: datagrid-ai-prompt-styling
 
 The .NET MAUI DataGrid control allows you to customize the appearance of the AI Smart Assistant feature to match your application's design requirements. You can modify various visual aspects of the AI Smart Assistant panel, including colors, fonts, and layout.
 
-![DataGrid AI Smart Assistant Styling](images/datagrid-ai-smart-assistant-styling.png)
+**AI Smart Assistant styling in the .NET MAUI DataGrid**
+
+![.NET MAUI DataGrid AI Smart Assistant showing custom styling for the panel and prompts](images/datagrid-ai-smart-assistant-styling.png)
 
 ## Style the AI Smart Assistant Input
 

--- a/controls/datagrid/smart-ai-features/ai-assistant/templates.md
+++ b/controls/datagrid/smart-ai-features/ai-assistant/templates.md
@@ -24,7 +24,7 @@ An example of `AIViewTemplate`:
 
 This is how the custom `AIViewTemplate` looks like when applied:
 
-![DataGrid AI Smart Assistant Custom View Templates](images/datagrid-ai-smart-assistant-view-templates.png)
+![.NET MAUI DataGrid AI Smart Assistant showing a custom AIViewTemplate](images/datagrid-ai-smart-assistant-view-templates.png)
 
 An example of `EmptyContentTemplate`:
 
@@ -32,7 +32,7 @@ An example of `EmptyContentTemplate`:
 
 This is how the custom `EmptyContentTemplate` looks like when applied:
 
-![DataGrid AI Smart Assistant Custom Empty Templates](images/datagrid-ai-smart-assistant-empty-templates.png)
+![.NET MAUI DataGrid AI Smart Assistant showing a custom EmptyContentTemplate](images/datagrid-ai-smart-assistant-empty-templates.png)
 
 >important The DataGrid AI Smart Assistant examples in the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) use a Telerik-hosted AI service for demonstration purposes only. 
 >You have to configure your own AI service for the AI Smart Assistant to work in your application.

--- a/controls/datagrid/theming-and-styles/columns-styling.md
+++ b/controls/datagrid/theming-and-styles/columns-styling.md
@@ -57,13 +57,13 @@ In addition to the column header text, the column header can contain the followi
 
     You can check how the individual indicators look on Windows below:
 
-    ![Telerik DataGrid Filtering and Sorting indicators](../images/datagrid-styling-indicators-individual.png)
+    ![Telerik UI for .NET MAUI DataGrid header showing individual filtering and sorting indicators in a column header on Windows.](../images/datagrid-styling-indicators-individual.png)
 
     * `Universal`&mdash;A single indicator will be used when any data operation (filtering, sorting or grouping) is applied. If sorting is applied, the sort indicator won't be displayed, only the universal indicator. If filtering is applied, in addition to the universal indicator, the filter indicator takes its active color (the active color can be modified through the `DataGridColumnHeaderStyle`'s `FilterIndicatorActiveTextColor` property).
 
     Check below how the indicators are displayed in `DataOperationIndicationMode`.`Universal`:
 
-    ![Telerik DataGrid Universal Indicator](../images/datagrid-styling-indicators-universal.png)
+    ![Telerik UI for .NET MAUI DataGrid header showing the universal data operation indicator in a column header on Windows.](../images/datagrid-styling-indicators-universal.png)
 
 ### Filter Indicator Styling
 
@@ -87,6 +87,8 @@ The `SortIndicator` appears once the `RadDataGridColumnHeader` is sorted (tapped
 * `SortIndicatorDescendingText`&mdash;Defines the text of the sort indicator when the sorting is descending.
 * `SortIndicatorHorizontalOptions`&mdash;Defines the horizontal options of the sort indicator.
 * `Font Options`(`SortIndicatorFontFamily`, `SortIndicatorFontSize`, `SortIndicatorFontAttributes`)&mdash;Define the font options to the sort indicator text. 
+
+**XAML example for styling the DataGrid sort indicator**
 
 ```xaml
 <Style TargetType="telerik:DataGridColumnHeaderAppearance">
@@ -165,7 +167,7 @@ Here is an example how to set this property:
 
 And this is how the column style looks when the properties for customizing the column are applied:
 
-![DataGrid Columns Styling](../images/datagrid-columns-styling.png)
+![Telerik UI for .NET MAUI DataGrid with customized column header, cell, and editor styling applied.](../images/datagrid-columns-styling.png)
 
 >note The `CellEditorStyle` is not applied to the built-in columns when they have a custom `CellEditTemplate`.
 
@@ -178,9 +180,13 @@ And this is how the column style looks when the properties for customizing the c
 * `Font Options` (`TextFontFamily`, `TextFontAttributes`, `TextFontSize`)&mdash;Define the font options to the text part of the `ColumnFooter`.
 * `Text Alignment` (`TextMargin`, `HorizontalTextAlignment`, `VerticalTextAlignment`)&mdash;Define the positioning for the text part of the `ColumnFooter`.
 
+**Example of styling the DataGrid column footer**
+
 <snippet id='datagrid-columnstyle-footerstyle' />
 
-![DataGrid Column Footer](../images/column-footer-style.png)
+**Customized DataGrid column footer styling**
+
+![Telerik UI for .NET MAUI DataGrid column footer showing customized footer styling.](../images/column-footer-style.png)
 
 ## See Also
 

--- a/controls/datagrid/theming-and-styles/columns-styling.md
+++ b/controls/datagrid/theming-and-styles/columns-styling.md
@@ -88,7 +88,7 @@ The `SortIndicator` appears once the `RadDataGridColumnHeader` is sorted (tapped
 * `SortIndicatorHorizontalOptions`&mdash;Defines the horizontal options of the sort indicator.
 * `Font Options`(`SortIndicatorFontFamily`, `SortIndicatorFontSize`, `SortIndicatorFontAttributes`)&mdash;Define the font options to the sort indicator text. 
 
-**XAML example for styling the DataGrid sort indicator**
+>caption XAML example for styling the DataGrid sort indicator
 
 ```xaml
 <Style TargetType="telerik:DataGridColumnHeaderAppearance">
@@ -180,11 +180,11 @@ And this is how the column style looks when the properties for customizing the c
 * `Font Options` (`TextFontFamily`, `TextFontAttributes`, `TextFontSize`)&mdash;Define the font options to the text part of the `ColumnFooter`.
 * `Text Alignment` (`TextMargin`, `HorizontalTextAlignment`, `VerticalTextAlignment`)&mdash;Define the positioning for the text part of the `ColumnFooter`.
 
-**Example of styling the DataGrid column footer**
+>caption Example of styling the DataGrid column footer
 
 <snippet id='datagrid-columnstyle-footerstyle' />
 
-**Customized DataGrid column footer styling**
+>caption Customized DataGrid column footer styling
 
 ![Telerik UI for .NET MAUI DataGrid column footer showing customized footer styling.](../images/column-footer-style.png)
 

--- a/controls/datagrid/theming-and-styles/group-header-styling.md
+++ b/controls/datagrid/theming-and-styles/group-header-styling.md
@@ -71,7 +71,7 @@ The following example demonstrates how to apply a sample `GroupHeaderStyle` to t
 
 Check the result at the image below:
 
-![Telerik .NET MAUI DataGrid Group Header Style](../images/datagrid-grouping-groupheaderstyle.png)
+![Telerik UI for .NET MAUI DataGrid showing customized group header styling in a grouped grid.](../images/datagrid-grouping-groupheaderstyle.png)
 
 ## See Also
 

--- a/controls/datagrid/theming-and-styles/style-selectors.md
+++ b/controls/datagrid/theming-and-styles/style-selectors.md
@@ -85,7 +85,7 @@ The following example demonstrates how to apply the style selectors on the DataG
 
 This is how the DataGrid control will look when `CellContentStyleSelector` is applied.
 
-![.NET MAUI DataGrid Cell and Group Header Style Selectors](../images/datagrid-style-selector.png)
+![Telerik UI for .NET MAUI DataGrid showing cell content and group header style selectors applied in the grid.](../images/datagrid-style-selector.png)
 
 > For the DataGrid Style Selector example, go to the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) and navigate to the **DataGrid > Styling** category.
 
@@ -115,7 +115,7 @@ The following example demonstrates how to apply the style selectors on the DataG
 
 This is how the DataGrid control looks when applying the `RowBackgroundStyleSelector`.
 
-![.NET MAUI DataGrid Row Background Style Selector](../images/datagrid-rowbackground-style-selector.png)
+![Telerik UI for .NET MAUI DataGrid showing row background style selector styling for rows, alternate rows, and row details.](../images/datagrid-rowbackground-style-selector.png)
 
 > For the DataGrid Row Background Style Selector example, go to the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) and navigate to the **DataGrid > Styling** category.
 

--- a/controls/datagrid/theming-and-styles/style-selectors.md
+++ b/controls/datagrid/theming-and-styles/style-selectors.md
@@ -85,7 +85,7 @@ The following example demonstrates how to apply the style selectors on the DataG
 
 This is how the DataGrid control will look when `CellContentStyleSelector` is applied.
 
-![Telerik UI for .NET MAUI DataGrid showing cell content and group header style selectors applied in the grid.](../images/datagrid-style-selector.png)
+![Telerik UI for .NET MAUI DataGrid showing cell content and group header style selectors applied](../images/datagrid-style-selector.png)
 
 > For the DataGrid Style Selector example, go to the [SDKBrowser Demo Application]({%slug sdkbrowser-app%}) and navigate to the **DataGrid > Styling** category.
 

--- a/font-icons/examples-icons.md
+++ b/font-icons/examples-icons.md
@@ -13,171 +13,171 @@ You can choose any of the available Telerik font icons:
 
 | Icon | Name | XAML | Code |
 | ---- | ---- | ---- | ---- |
-| ![](images/sort-descent.png) | sort descent | __\&#xe800;__ | __\ue800__ |
-| ![](images/star-empty.png) | star-empty | __\&#xe801;__ | __\ue801__ |
-| ![](images/filter.png) | filter | __\&#xe802;__ | __\ue802__ |
-| ![](images/sort-ascent.png) | sort ascent | __\&#xe803;__ | __\ue803__ |
-| ![](images/group.png) | group | __\&#xe804;__ | __\ue804__ |
-| ![](images/star.png) | star | __\&#xe805;__ | __\ue805__ |
-| ![](images/right-dir.png) | right-dir | __\&#xe806;__ | __\ue806__ |
-| ![](images/dots-vert.png) | dots vert | __\&#xe807;__ | __\ue807__ |
-| ![](images/menu.png) | menu | __\&#xf008;__ | __\uf008__ |
-| ![](images/check.png) | check | __\&#xe876;__ | __\ue876__ |
-| ![](images/cancel.png) | cancel | __\&#xe877;__ | __\ue877__ |
-| ![](images/dot.png) | dot | __\&#xe80b;__ | __\ue80b__ |
-| ![](images/dot-3.png) | dot-3 | __\&#xe80c;__ | __\ue80c__ |
-| ![](images/down-dir.png) | down-dir | __\&#xe80d;__ | __\ue80d__ |
-| ![](images/chevron-left.png) | chevron left | __\&#xe80e;__ | __\ue80e__ |
-| ![](images/configure.png) | configure | __\&#xe80f;__ | __\ue80f__ |
-| ![](images/search.png) | search | __\&#xe810;__ | __\ue810__ |
-| ![](images/up-dir.png) | up-dir | __\&#xe811;__ | __\ue811__ |
-| ![](images/pattern.png) | pattern | __\&#xe812;__ | __\ue812__ |
-| ![](images/add.png) | add | __\&#xe813;__ | __\ue813__ |
-| ![](images/right-dir-outlines.png) | right-dir-outlines | __\&#xe814;__ | __\ue814__ |
-| ![](images/info.png) | info | __\&#xe815;__ | __\ue815__ |
-| ![](images/down-dir-outlines.png) | down-dir-outlines | __\&#xe816;__ | __\ue816__ |
-| ![](images/bin-solid.png)  | bin-solid | __\&#xe817;__ | __\ue817__ |
-| ![](images/edit.png) | edit | __\&#xe818;__ | __\ue818__ |
-| ![](images/copy.png) | copy | __\&#xe819;__ | __\ue819__ |
-| ![](images/arrow-up.png) | arrow-up | __\&#xe81a;__ | __\ue81a__ |
-| ![](images/airplane.png) | airplane | __\&#xe81c;__ | __\ue81c__ |
-| ![](images/pdf.png) | pdf | __\&#xe81d;__ | __\ue81d__ |
-| ![](images/encoding.png) | encoding | __\&#xe81e;__ | __\ue81e__ |
-| ![](images/length.png) | length | __\&#xe81f;__ | __\ue81f__ |
-| ![](images/arrow-right.png) | arrow-right | __\&#xe820;__ | __\ue820__ |
-| ![](images/contacts.png) | contacts | __\&#xe821;__ | __\ue821__ |
-| ![](images/cog-outlines.png) | cog-outlines | __\&#xe822;__ | __\ue822__ |
-| ![](images/type.png) | type | __\&#xe823;__ | __\ue823__ |
-| ![](images/location.png) | location | __\&#xe83d;__ | __\ue83d__ |
-| ![](images/link.png) | link | __\&#xe83e;__ | __\ue83e__ |
-| ![](images/archive.png) | archive | __\&#xe826;__ | __\ue826__ |
-| ![](images/bin.png) | bin | __\&#xe827;__ | __\ue827__ |
-| ![](images/draft.png) | draft | __\&#xe828;__ | __\ue828__ |
-| ![](images/folder-open.png) | folder-open | __\&#xe829;__ | __\ue829__ |
-| ![](images/folder.png) | folder | __\&#xe82a;__ | __\ue82a__ |
-| ![](images/group.png) | group | __\&#xe82b;__ | __\ue82b__ |
-| ![](images/item.png) | item | __\&#xe82c;__ | __\ue82c__ |
-| ![](images/sent.png) | sent | __\&#xe82d;__ | __\ue82d__ |
-| ![](images/spam.png) | spam | __\&#xe82e;__ | __\ue82e__ |
-| ![](images/warning.png) | warning | __\&#xe82f;__ | __\ue82f__ |
-| ![](images/lock.png) | lock | __\&#xe830;__ | __\ue830__ |
-| ![](images/thickness.png) | thickness | __\&#xe831;__ | __\ue831__ |
-| ![](images/car.png) | car | __\&#xe832;__ | __\ue832__ |
-| ![](images/shopping-bag.png) | shopping-bag | __\&#xe833;__ | __\ue833__ |
-| ![](images/coffee-cup.png) | coffee-cup | __\&#xe834;__ | __\ue834__ |
-| ![](images/get-money.png) | get-money | __\&#xe835;__ | __\ue835__ |
-| ![](images/shopping-user.png) | shopping-user | __\&#xe836;__ | __\ue836__ |
-| ![](images/group-users.png) | group users | __\&#xe837;__ | __\ue837__ |
-| ![](images/dashboard.png) | dashboard | __\&#xe838;__ | __\ue838__ |
-| ![](images/first.png) | first | __\&#xe839;__ | __\ue839__ |
-| ![](images/cake.png) | cake | __\&#xe83a;__ | __\ue83a__ |
-| ![](images/chat.png) | chat | __\&#xe83b;__ | __\ue83b__ |
-| ![](images/book2.png) | book | __\&#xe83c;__ | __\ue83c__ |
-| ![](images/assets2.png) | assets | __\&#xe846;__ | __\ue846__ |
-| ![](images/book2.png) | book | __\&#xe847;__ | __\ue847__ |
-| ![](images/cancel2.png) | cancel | __\&#xe851;__ | __\ue851__ |
-| ![](images/design.png) | design | __\&#xe848;__ | __\ue848__ |
-| ![](images/graphics.png) | graphics | __\&#xe849;__ | __\ue849__ |
-| ![](images/picture.png) | picture | __\&#xe852;__ | __\ue852__ |
-| ![](images/font-size.png) | font-size | __\&#xe84b;__ | __\ue84b__ |
-| ![](images/template.png) | template | __\&#xe84c;__ | __\ue84c__ |
-| ![](images/wireframes.png) | wireframes | __\&#xe84d;__ | __\ue84d__ |
-| ![](images/distance.png) | distance | __\&#xe84e;__ | __\ue84e__ |
-| ![](images/stopwatch.png) | stopwatch | __\&#xe84f;__ | __\ue84f__ |
-| ![](images/play.png) | play | __\&#xe850;__ | __\ue850__ |
-| ![](images/code.png) | code | __\&#xe854;__ | __\ue854__ |
-| ![](images/analysis.png) | analysis | __\&#xe855;__ | __\ue855__ |
-| ![](images/network.png) | network | __\&#xe856;__ | __\ue856__ |
-| ![](images/network2.png) | network | __\&#xe857;__ | __\ue857__ |
-| ![](images/bar-chart.png) | bar-chart | __\&#xe858;__ | __\ue858__ |
-| ![](images/sap.png) | sap | __\&#xe859;__ | __\ue859__ |
-| ![](images/dba.png) | dba | __\&#xe85a;__ | __\ue85a__ |
-| ![](images/home.png) | home | __\&#xe85b;__ | __\ue85b__ |
-| ![](images/temperature.png) | temperature | __\&#xe85c;__ | __\ue85c__ |
-| ![](images/phone.png) | phone | __\&#xe85d;__ | __\ue85d__ |
-| ![](images/electricity.png) | electricity | __\&#xe85e;__ | __\ue85e__ |
-| ![](images/wifi.png) | wifi | __\&#xe85f;__ | __\ue85f__ |
-| ![](images/distance-horizontal.png) | distance-horizontal | __\&#xe860;__ | __\ue860__ |
-| ![](images/calendar-dayview.png) | calendar dayview | __\&#xe861;__ | __\ue861__ |
-| ![](images/calendar-multiday.png) | calendar multiday | __\&#xe862;__ | __\ue862__ |
-| ![](images/calendar-week.png) | calendar week | __\&#xe863;__ | __\ue863__ |
-| ![](images/calendar-month.png) | calendar month | __\&#xe864;__ | __\ue864__ |
-| ![](images/calendar-year.png) | calendar year | __\&#xe865;__ | __\ue865__ |
-| ![](images/calendar-selection-single.png) | calendar selection single | __\&#xe866;__ | __\ue866__ |
-| ![](images/calendar-selection-multiple.png) | calendar selection multiple | __\&#xe867;__ | __\ue867__ |
-| ![](images/calendar-selection-range.png) | calendar selection range | __\&#xe868;__ | __\ue868__ |
-| ![](images/gallery.png) | gallery | __\&#xe869;__ | __\ue869__ |
-| ![](images/camera.png) | camera | __\&#xe86a;__ | __\ue86a__ |
-| ![](images/crop-free.png) | crop free | __\&#xe86b;__ | __\ue86b__ |
-| ![](images/crop-original.png) | crop original | __\&#xe86c;__ | __\ue86c__ |
-| ![](images/crop-rect.png) | crop rect | __\&#xe86d;__ | __\ue86d__ |
-| ![](images/crop-circular.png) | crop circular | __\&#xe86e;__ | __\ue86e__ |
-| ![](images/badge.png) | badge | __\&#xe86f;__ | __\ue86f__ |
-| ![](images/notes.png) | notes | __\&#xe870;__ | __\ue870__ |
-| ![](images/time.png) | time | __\&#xe871;__ | __\ue871__ |
-| ![](images/calendar-agenda.png) | calendar agenda | __\&#xe872;__ | __\ue872__ |
-| ![](images/arrows.png) | arrows | __\&#xe873;__ | __\ue873__ |
-| ![](images/video-camera.png) | video-camera | __\&#xe87;__ | __\ue874__ |
-| ![](images/time.png) | check | __\&#xe878;__ | __\ue878__ |
-| ![](images/phone.png) | cancel | __\&#xe887;__ | __\ue887__ |
-| ![](images/text.png) | text | __\&#xe853;__ | __\ue853__ |
-| ![](images/arrow-down.png) | arrow-down | __\&#xe879;__ | __\ue879__ |
-| ![](images/flag.png) | flag | __\&#xe87a;__ | __\ue87a__ |
-| ![](images/save.png) | save | __\&#xe87b;__ | __\ue87b__ |
-| ![](images/share.png) | share | __\&#xe87c;__ | __\ue87c__ |
-| ![](images/menu-custom.png) | menu-custom | __\&#xe87d;__ | __\ue87d__ |
-| ![](images/heart-filled.png) | heart-filled | __\&#xe87e;__ | __\ue87e__ |
-| ![](images/heart-empty.png) | heart-empty | __\&#xe87f;__ | __\ue87f__ |
-| ![](images/reorder.png) | reorder | __\&#xe881;__ | __\ue881__ |
-| ![](images/arrow-box-left.png) | arrow-box-left | __\&#xe882;__ | __\ue882__ |
-| ![](images/arrow-box-right.png) | arrow-box-right | __\&#xe883;__ | __\ue883__ |
-| ![](images/bell.png) | bell | __\&#xe88a;__ | __\ue88a__ |
-| ![](images/chat.png) | chat | __\&#xe88b;__ | __\ue88b__ |
-| ![](images/phone.png) | phone | __\&#xe904;__ | __\ue887 |
-| ![](images/unpin.png) | unpin | __\&#xe88e;__ | __\ue88e__ |
-| ![](images/pin.png) | pin | __\&#xe88f;__ | __\ue88f__ |
-| ![](images/excel.png) | excel | __\&#xe896;__ | __\ue896__ |
-| ![](images/powerpoint.png) | powerpoint | __\&#xe897;__ | __\ue897__ |
-| ![](images/word.png) | word | __\&#xe898;__ | __\ue898__ |
-| ![](images/pdf.png) | pdf | __\&#xe899;__ | __\ue899__ |
-| ![](images/last.png) | last | __\&#xe89a;__ | __\ue89a__ |
-| ![](images/expand.png) | expand | __\&#xe89b;__ | __\ue89b__ |
-| ![](images/expand2.png) | expand 2 | __\&#xe89c;__ | __\ue89c__ |
-| ![](images/paint-bucket.png) | paint bucket | __\&#xe89d;__ | __\ue89d__ |
-| ![](images/mail.png) | mail | __\&#xe89e;__ | __\ue89e__ |
-| ![](images/promotion.png) | promotion | __\&#xe89f;__ | __\ue89f__ |
-| ![](images/scheduled.png) | scheduled | __\&#xe8a0;__ | __\ue8a0__ |
-| ![](images/label.png) | label | __\&#xe8a1;__ | __\ue8a1__ |
-| ![](images/drawer.png) | drawer | __\&#xe8a2;__ | __\ue8a2__ |
-| ![](images/social.png) | social | __\&#xe8a3;__ | __\ue8a3__ |
-| ![](images/shipping.png) | shipping | __\&#xe8a6;__ | __\ue8a6__ |
-| ![](images/products.png) | products | __\&#xe8a7;__ | __\ue8a7__ |
-| ![](images/customer.png) | customer | __\&#xe8a8;__ | __\ue8a8__ |
-| ![](images/export.png) | export | __\&#xe8a9;__ | __\ue8a9__ |
-| ![](images/info-outlines.png) | info-outlines | __\&#xe8ac;__ | __\ue8ac__ |
-| ![](images/contract.png) | contract | __\&#xe8dd;__ | __\ue8dd__ |
-| ![](images/enlarge.png) | enlarge | __\&#xe8de;__ | __\ue8de__ |
-| ![](images/translate.png) | translate | __\&#xe8df;__ | __\ue8df__ |
-| ![](images/emoji.png) | emoji | __\&#xe900;__ | __\ue900__ |
-| ![](images/brightness.png) | brightness | __\&#xe901;__ | __\ue901__ |
-| ![](images/flip-vertical.png) | flip-vertical | __\&#xe902;__ | __\ue902__ |
-| ![](images/flip-horizontal.png) | flip-horizontal | __\&#xe903;__ | __\ue903__ |
-| ![](images/rotate-cw.png) | rotate-cw | __\&#xe904;__ | __\ue904__ |
-| ![](images/rotate-ccw.png) | rotate-ccw | __\&#xe905;__ | __\ue905__ |
-| ![](images/crop.png) | crop | __\&#xe906;__ | __\ue906__ | 
-| ![](images/hue.png) | hue | __\&#xe907;__ | __\ue907__ |
-| ![](images/link-external.png) | link-external | __\&#xf08e;__ | __\uf08e__ |
-| ![](images/plus-squared.png) | plus-squared | __\&#xf0fe;__ | __\uf0fe__ |
-| ![](images/angle-left.png) | angle-left | __\&#xf104;__ | __\uf104__ |
-| ![](images/angle-right.png) | angle-right | __\&#xf105;__ | __\uf105__ |
-| ![](images/angle-up.png) | angle-up | __\&#xf106;__ | __\uf106__ |
-| ![](images/angle-down.png) | angle-down | __\&#xf107;__ | __\uf107__ |
-| ![](images/spinner.png) | spinner | __\&#xf110;__ | __\uf110__ |
-| ![](images/arrow-circled-left.png) | arrow-circled-left | __\&#xf137;__ | __\uf137__ |
-| ![](images/arrow-circled-right.png) | arrow-circled-right | __\&#xf138;__ | __\uf138__ |
-| ![](images/minus-squared.png) | minus-squared | __\&#xf146;__ | __\uf146__ |
-| ![](images/minus-squared-alt.png) | minus-squared-alt | __\&#xf147;__ | __\uf147__ |
-| ![](images/plus-squared-alt.png) | plus-squared-alt | __\&#xf196;__ | __\uf196__ |
+| ![Telerik UI for .NET MAUI example font icon: sort-descent](images/sort-descent.png) | sort descent | __\&#xe800;__ | __\ue800__ |
+| ![Telerik UI for .NET MAUI example font icon: star-empty](images/star-empty.png) | star-empty | __\&#xe801;__ | __\ue801__ |
+| ![Telerik UI for .NET MAUI example font icon: filter](images/filter.png) | filter | __\&#xe802;__ | __\ue802__ |
+| ![Telerik UI for .NET MAUI example font icon: sort-ascent](images/sort-ascent.png) | sort ascent | __\&#xe803;__ | __\ue803__ |
+| ![Telerik UI for .NET MAUI example font icon: group](images/group.png) | group | __\&#xe804;__ | __\ue804__ |
+| ![Telerik UI for .NET MAUI example font icon: star](images/star.png) | star | __\&#xe805;__ | __\ue805__ |
+| ![Telerik UI for .NET MAUI example font icon: right-dir](images/right-dir.png) | right-dir | __\&#xe806;__ | __\ue806__ |
+| ![Telerik UI for .NET MAUI example font icon: dots-vert](images/dots-vert.png) | dots vert | __\&#xe807;__ | __\ue807__ |
+| ![Telerik UI for .NET MAUI example font icon: menu](images/menu.png) | menu | __\&#xf008;__ | __\uf008__ |
+| ![Telerik UI for .NET MAUI example font icon: check](images/check.png) | check | __\&#xe876;__ | __\ue876__ |
+| ![Telerik UI for .NET MAUI example font icon: cancel](images/cancel.png) | cancel | __\&#xe877;__ | __\ue877__ |
+| ![Telerik UI for .NET MAUI example font icon: dot](images/dot.png) | dot | __\&#xe80b;__ | __\ue80b__ |
+| ![Telerik UI for .NET MAUI example font icon: dot-3](images/dot-3.png) | dot-3 | __\&#xe80c;__ | __\ue80c__ |
+| ![Telerik UI for .NET MAUI example font icon: down-dir](images/down-dir.png) | down-dir | __\&#xe80d;__ | __\ue80d__ |
+| ![Telerik UI for .NET MAUI example font icon: chevron-left](images/chevron-left.png) | chevron left | __\&#xe80e;__ | __\ue80e__ |
+| ![Telerik UI for .NET MAUI example font icon: configure](images/configure.png) | configure | __\&#xe80f;__ | __\ue80f__ |
+| ![Telerik UI for .NET MAUI example font icon: search](images/search.png) | search | __\&#xe810;__ | __\ue810__ |
+| ![Telerik UI for .NET MAUI example font icon: up-dir](images/up-dir.png) | up-dir | __\&#xe811;__ | __\ue811__ |
+| ![Telerik UI for .NET MAUI example font icon: pattern](images/pattern.png) | pattern | __\&#xe812;__ | __\ue812__ |
+| ![Telerik UI for .NET MAUI example font icon: add](images/add.png) | add | __\&#xe813;__ | __\ue813__ |
+| ![Telerik UI for .NET MAUI example font icon: right-dir-outlines](images/right-dir-outlines.png) | right-dir-outlines | __\&#xe814;__ | __\ue814__ |
+| ![Telerik UI for .NET MAUI example font icon: info](images/info.png) | info | __\&#xe815;__ | __\ue815__ |
+| ![Telerik UI for .NET MAUI example font icon: down-dir-outlines](images/down-dir-outlines.png) | down-dir-outlines | __\&#xe816;__ | __\ue816__ |
+| ![Telerik UI for .NET MAUI example font icon: bin-solid](images/bin-solid.png)  | bin-solid | __\&#xe817;__ | __\ue817__ |
+| ![Telerik UI for .NET MAUI example font icon: edit](images/edit.png) | edit | __\&#xe818;__ | __\ue818__ |
+| ![Telerik UI for .NET MAUI example font icon: copy](images/copy.png) | copy | __\&#xe819;__ | __\ue819__ |
+| ![Telerik UI for .NET MAUI example font icon: arrow-up](images/arrow-up.png) | arrow-up | __\&#xe81a;__ | __\ue81a__ |
+| ![Telerik UI for .NET MAUI example font icon: airplane](images/airplane.png) | airplane | __\&#xe81c;__ | __\ue81c__ |
+| ![Telerik UI for .NET MAUI example font icon: pdf](images/pdf.png) | pdf | __\&#xe81d;__ | __\ue81d__ |
+| ![Telerik UI for .NET MAUI example font icon: encoding](images/encoding.png) | encoding | __\&#xe81e;__ | __\ue81e__ |
+| ![Telerik UI for .NET MAUI example font icon: length](images/length.png) | length | __\&#xe81f;__ | __\ue81f__ |
+| ![Telerik UI for .NET MAUI example font icon: arrow-right](images/arrow-right.png) | arrow-right | __\&#xe820;__ | __\ue820__ |
+| ![Telerik UI for .NET MAUI example font icon: contacts](images/contacts.png) | contacts | __\&#xe821;__ | __\ue821__ |
+| ![Telerik UI for .NET MAUI example font icon: cog-outlines](images/cog-outlines.png) | cog-outlines | __\&#xe822;__ | __\ue822__ |
+| ![Telerik UI for .NET MAUI example font icon: type](images/type.png) | type | __\&#xe823;__ | __\ue823__ |
+| ![Telerik UI for .NET MAUI example font icon: location](images/location.png) | location | __\&#xe83d;__ | __\ue83d__ |
+| ![Telerik UI for .NET MAUI example font icon: link](images/link.png) | link | __\&#xe83e;__ | __\ue83e__ |
+| ![Telerik UI for .NET MAUI example font icon: archive](images/archive.png) | archive | __\&#xe826;__ | __\ue826__ |
+| ![Telerik UI for .NET MAUI example font icon: bin](images/bin.png) | bin | __\&#xe827;__ | __\ue827__ |
+| ![Telerik UI for .NET MAUI example font icon: draft](images/draft.png) | draft | __\&#xe828;__ | __\ue828__ |
+| ![Telerik UI for .NET MAUI example font icon: folder-open](images/folder-open.png) | folder-open | __\&#xe829;__ | __\ue829__ |
+| ![Telerik UI for .NET MAUI example font icon: folder](images/folder.png) | folder | __\&#xe82a;__ | __\ue82a__ |
+| ![Telerik UI for .NET MAUI example font icon: group](images/group.png) | group | __\&#xe82b;__ | __\ue82b__ |
+| ![Telerik UI for .NET MAUI example font icon: item](images/item.png) | item | __\&#xe82c;__ | __\ue82c__ |
+| ![Telerik UI for .NET MAUI example font icon: sent](images/sent.png) | sent | __\&#xe82d;__ | __\ue82d__ |
+| ![Telerik UI for .NET MAUI example font icon: spam](images/spam.png) | spam | __\&#xe82e;__ | __\ue82e__ |
+| ![Telerik UI for .NET MAUI example font icon: warning](images/warning.png) | warning | __\&#xe82f;__ | __\ue82f__ |
+| ![Telerik UI for .NET MAUI example font icon: lock](images/lock.png) | lock | __\&#xe830;__ | __\ue830__ |
+| ![Telerik UI for .NET MAUI example font icon: thickness](images/thickness.png) | thickness | __\&#xe831;__ | __\ue831__ |
+| ![Telerik UI for .NET MAUI example font icon: car](images/car.png) | car | __\&#xe832;__ | __\ue832__ |
+| ![Telerik UI for .NET MAUI example font icon: shopping-bag](images/shopping-bag.png) | shopping-bag | __\&#xe833;__ | __\ue833__ |
+| ![Telerik UI for .NET MAUI example font icon: coffee-cup](images/coffee-cup.png) | coffee-cup | __\&#xe834;__ | __\ue834__ |
+| ![Telerik UI for .NET MAUI example font icon: get-money](images/get-money.png) | get-money | __\&#xe835;__ | __\ue835__ |
+| ![Telerik UI for .NET MAUI example font icon: shopping-user](images/shopping-user.png) | shopping-user | __\&#xe836;__ | __\ue836__ |
+| ![Telerik UI for .NET MAUI example font icon: group-users](images/group-users.png) | group users | __\&#xe837;__ | __\ue837__ |
+| ![Telerik UI for .NET MAUI example font icon: dashboard](images/dashboard.png) | dashboard | __\&#xe838;__ | __\ue838__ |
+| ![Telerik UI for .NET MAUI example font icon: first](images/first.png) | first | __\&#xe839;__ | __\ue839__ |
+| ![Telerik UI for .NET MAUI example font icon: cake](images/cake.png) | cake | __\&#xe83a;__ | __\ue83a__ |
+| ![Telerik UI for .NET MAUI example font icon: chat](images/chat.png) | chat | __\&#xe83b;__ | __\ue83b__ |
+| ![Telerik UI for .NET MAUI example font icon: book2](images/book2.png) | book | __\&#xe83c;__ | __\ue83c__ |
+| ![Telerik UI for .NET MAUI example font icon: assets2](images/assets2.png) | assets | __\&#xe846;__ | __\ue846__ |
+| ![Telerik UI for .NET MAUI example font icon: book2](images/book2.png) | book | __\&#xe847;__ | __\ue847__ |
+| ![Telerik UI for .NET MAUI example font icon: cancel2](images/cancel2.png) | cancel | __\&#xe851;__ | __\ue851__ |
+| ![Telerik UI for .NET MAUI example font icon: design](images/design.png) | design | __\&#xe848;__ | __\ue848__ |
+| ![Telerik UI for .NET MAUI example font icon: graphics](images/graphics.png) | graphics | __\&#xe849;__ | __\ue849__ |
+| ![Telerik UI for .NET MAUI example font icon: picture](images/picture.png) | picture | __\&#xe852;__ | __\ue852__ |
+| ![Telerik UI for .NET MAUI example font icon: font-size](images/font-size.png) | font-size | __\&#xe84b;__ | __\ue84b__ |
+| ![Telerik UI for .NET MAUI example font icon: template](images/template.png) | template | __\&#xe84c;__ | __\ue84c__ |
+| ![Telerik UI for .NET MAUI example font icon: wireframes](images/wireframes.png) | wireframes | __\&#xe84d;__ | __\ue84d__ |
+| ![Telerik UI for .NET MAUI example font icon: distance](images/distance.png) | distance | __\&#xe84e;__ | __\ue84e__ |
+| ![Telerik UI for .NET MAUI example font icon: stopwatch](images/stopwatch.png) | stopwatch | __\&#xe84f;__ | __\ue84f__ |
+| ![Telerik UI for .NET MAUI example font icon: play](images/play.png) | play | __\&#xe850;__ | __\ue850__ |
+| ![Telerik UI for .NET MAUI example font icon: code](images/code.png) | code | __\&#xe854;__ | __\ue854__ |
+| ![Telerik UI for .NET MAUI example font icon: analysis](images/analysis.png) | analysis | __\&#xe855;__ | __\ue855__ |
+| ![Telerik UI for .NET MAUI example font icon: network](images/network.png) | network | __\&#xe856;__ | __\ue856__ |
+| ![Telerik UI for .NET MAUI example font icon: network2](images/network2.png) | network | __\&#xe857;__ | __\ue857__ |
+| ![Telerik UI for .NET MAUI example font icon: bar-chart](images/bar-chart.png) | bar-chart | __\&#xe858;__ | __\ue858__ |
+| ![Telerik UI for .NET MAUI example font icon: sap](images/sap.png) | sap | __\&#xe859;__ | __\ue859__ |
+| ![Telerik UI for .NET MAUI example font icon: dba](images/dba.png) | dba | __\&#xe85a;__ | __\ue85a__ |
+| ![Telerik UI for .NET MAUI example font icon: home](images/home.png) | home | __\&#xe85b;__ | __\ue85b__ |
+| ![Telerik UI for .NET MAUI example font icon: temperature](images/temperature.png) | temperature | __\&#xe85c;__ | __\ue85c__ |
+| ![Telerik UI for .NET MAUI example font icon: phone](images/phone.png) | phone | __\&#xe85d;__ | __\ue85d__ |
+| ![Telerik UI for .NET MAUI example font icon: electricity](images/electricity.png) | electricity | __\&#xe85e;__ | __\ue85e__ |
+| ![Telerik UI for .NET MAUI example font icon: wifi](images/wifi.png) | wifi | __\&#xe85f;__ | __\ue85f__ |
+| ![Telerik UI for .NET MAUI example font icon: distance-horizontal](images/distance-horizontal.png) | distance-horizontal | __\&#xe860;__ | __\ue860__ |
+| ![Telerik UI for .NET MAUI example font icon: calendar-dayview](images/calendar-dayview.png) | calendar dayview | __\&#xe861;__ | __\ue861__ |
+| ![Telerik UI for .NET MAUI example font icon: calendar-multiday](images/calendar-multiday.png) | calendar multiday | __\&#xe862;__ | __\ue862__ |
+| ![Telerik UI for .NET MAUI example font icon: calendar-week](images/calendar-week.png) | calendar week | __\&#xe863;__ | __\ue863__ |
+| ![Telerik UI for .NET MAUI example font icon: calendar-month](images/calendar-month.png) | calendar month | __\&#xe864;__ | __\ue864__ |
+| ![Telerik UI for .NET MAUI example font icon: calendar-year](images/calendar-year.png) | calendar year | __\&#xe865;__ | __\ue865__ |
+| ![Telerik UI for .NET MAUI example font icon: calendar-selection-single](images/calendar-selection-single.png) | calendar selection single | __\&#xe866;__ | __\ue866__ |
+| ![Telerik UI for .NET MAUI example font icon: calendar-selection-multiple](images/calendar-selection-multiple.png) | calendar selection multiple | __\&#xe867;__ | __\ue867__ |
+| ![Telerik UI for .NET MAUI example font icon: calendar-selection-range](images/calendar-selection-range.png) | calendar selection range | __\&#xe868;__ | __\ue868__ |
+| ![Telerik UI for .NET MAUI example font icon: gallery](images/gallery.png) | gallery | __\&#xe869;__ | __\ue869__ |
+| ![Telerik UI for .NET MAUI example font icon: camera](images/camera.png) | camera | __\&#xe86a;__ | __\ue86a__ |
+| ![Telerik UI for .NET MAUI example font icon: crop-free](images/crop-free.png) | crop free | __\&#xe86b;__ | __\ue86b__ |
+| ![Telerik UI for .NET MAUI example font icon: crop-original](images/crop-original.png) | crop original | __\&#xe86c;__ | __\ue86c__ |
+| ![Telerik UI for .NET MAUI example font icon: crop-rect](images/crop-rect.png) | crop rect | __\&#xe86d;__ | __\ue86d__ |
+| ![Telerik UI for .NET MAUI example font icon: crop-circular](images/crop-circular.png) | crop circular | __\&#xe86e;__ | __\ue86e__ |
+| ![Telerik UI for .NET MAUI example font icon: badge](images/badge.png) | badge | __\&#xe86f;__ | __\ue86f__ |
+| ![Telerik UI for .NET MAUI example font icon: notes](images/notes.png) | notes | __\&#xe870;__ | __\ue870__ |
+| ![Telerik UI for .NET MAUI example font icon: time](images/time.png) | time | __\&#xe871;__ | __\ue871__ |
+| ![Telerik UI for .NET MAUI example font icon: calendar-agenda](images/calendar-agenda.png) | calendar agenda | __\&#xe872;__ | __\ue872__ |
+| ![Telerik UI for .NET MAUI example font icon: arrows](images/arrows.png) | arrows | __\&#xe873;__ | __\ue873__ |
+| ![Telerik UI for .NET MAUI example font icon: video-camera](images/video-camera.png) | video-camera | __\&#xe87;__ | __\ue874__ |
+| ![Telerik UI for .NET MAUI example font icon: time](images/time.png) | check | __\&#xe878;__ | __\ue878__ |
+| ![Telerik UI for .NET MAUI example font icon: phone](images/phone.png) | cancel | __\&#xe887;__ | __\ue887__ |
+| ![Telerik UI for .NET MAUI example font icon: text](images/text.png) | text | __\&#xe853;__ | __\ue853__ |
+| ![Telerik UI for .NET MAUI example font icon: arrow-down](images/arrow-down.png) | arrow-down | __\&#xe879;__ | __\ue879__ |
+| ![Telerik UI for .NET MAUI example font icon: flag](images/flag.png) | flag | __\&#xe87a;__ | __\ue87a__ |
+| ![Telerik UI for .NET MAUI example font icon: save](images/save.png) | save | __\&#xe87b;__ | __\ue87b__ |
+| ![Telerik UI for .NET MAUI example font icon: share](images/share.png) | share | __\&#xe87c;__ | __\ue87c__ |
+| ![Telerik UI for .NET MAUI example font icon: menu-custom](images/menu-custom.png) | menu-custom | __\&#xe87d;__ | __\ue87d__ |
+| ![Telerik UI for .NET MAUI example font icon: heart-filled](images/heart-filled.png) | heart-filled | __\&#xe87e;__ | __\ue87e__ |
+| ![Telerik UI for .NET MAUI example font icon: heart-empty](images/heart-empty.png) | heart-empty | __\&#xe87f;__ | __\ue87f__ |
+| ![Telerik UI for .NET MAUI example font icon: reorder](images/reorder.png) | reorder | __\&#xe881;__ | __\ue881__ |
+| ![Telerik UI for .NET MAUI example font icon: arrow-box-left](images/arrow-box-left.png) | arrow-box-left | __\&#xe882;__ | __\ue882__ |
+| ![Telerik UI for .NET MAUI example font icon: arrow-box-right](images/arrow-box-right.png) | arrow-box-right | __\&#xe883;__ | __\ue883__ |
+| ![Telerik UI for .NET MAUI example font icon: bell](images/bell.png) | bell | __\&#xe88a;__ | __\ue88a__ |
+| ![Telerik UI for .NET MAUI example font icon: chat](images/chat.png) | chat | __\&#xe88b;__ | __\ue88b__ |
+| ![Telerik UI for .NET MAUI example font icon: phone](images/phone.png) | phone | __\&#xe904;__ | __\ue887 |
+| ![Telerik UI for .NET MAUI example font icon: unpin](images/unpin.png) | unpin | __\&#xe88e;__ | __\ue88e__ |
+| ![Telerik UI for .NET MAUI example font icon: pin](images/pin.png) | pin | __\&#xe88f;__ | __\ue88f__ |
+| ![Telerik UI for .NET MAUI example font icon: excel](images/excel.png) | excel | __\&#xe896;__ | __\ue896__ |
+| ![Telerik UI for .NET MAUI example font icon: powerpoint](images/powerpoint.png) | powerpoint | __\&#xe897;__ | __\ue897__ |
+| ![Telerik UI for .NET MAUI example font icon: word](images/word.png) | word | __\&#xe898;__ | __\ue898__ |
+| ![Telerik UI for .NET MAUI example font icon: pdf](images/pdf.png) | pdf | __\&#xe899;__ | __\ue899__ |
+| ![Telerik UI for .NET MAUI example font icon: last](images/last.png) | last | __\&#xe89a;__ | __\ue89a__ |
+| ![Telerik UI for .NET MAUI example font icon: expand](images/expand.png) | expand | __\&#xe89b;__ | __\ue89b__ |
+| ![Telerik UI for .NET MAUI example font icon: expand2](images/expand2.png) | expand 2 | __\&#xe89c;__ | __\ue89c__ |
+| ![Telerik UI for .NET MAUI example font icon: paint-bucket](images/paint-bucket.png) | paint bucket | __\&#xe89d;__ | __\ue89d__ |
+| ![Telerik UI for .NET MAUI example font icon: mail](images/mail.png) | mail | __\&#xe89e;__ | __\ue89e__ |
+| ![Telerik UI for .NET MAUI example font icon: promotion](images/promotion.png) | promotion | __\&#xe89f;__ | __\ue89f__ |
+| ![Telerik UI for .NET MAUI example font icon: scheduled](images/scheduled.png) | scheduled | __\&#xe8a0;__ | __\ue8a0__ |
+| ![Telerik UI for .NET MAUI example font icon: label](images/label.png) | label | __\&#xe8a1;__ | __\ue8a1__ |
+| ![Telerik UI for .NET MAUI example font icon: drawer](images/drawer.png) | drawer | __\&#xe8a2;__ | __\ue8a2__ |
+| ![Telerik UI for .NET MAUI example font icon: social](images/social.png) | social | __\&#xe8a3;__ | __\ue8a3__ |
+| ![Telerik UI for .NET MAUI example font icon: shipping](images/shipping.png) | shipping | __\&#xe8a6;__ | __\ue8a6__ |
+| ![Telerik UI for .NET MAUI example font icon: products](images/products.png) | products | __\&#xe8a7;__ | __\ue8a7__ |
+| ![Telerik UI for .NET MAUI example font icon: customer](images/customer.png) | customer | __\&#xe8a8;__ | __\ue8a8__ |
+| ![Telerik UI for .NET MAUI example font icon: export](images/export.png) | export | __\&#xe8a9;__ | __\ue8a9__ |
+| ![Telerik UI for .NET MAUI example font icon: info-outlines](images/info-outlines.png) | info-outlines | __\&#xe8ac;__ | __\ue8ac__ |
+| ![Telerik UI for .NET MAUI example font icon: contract](images/contract.png) | contract | __\&#xe8dd;__ | __\ue8dd__ |
+| ![Telerik UI for .NET MAUI example font icon: enlarge](images/enlarge.png) | enlarge | __\&#xe8de;__ | __\ue8de__ |
+| ![Telerik UI for .NET MAUI example font icon: translate](images/translate.png) | translate | __\&#xe8df;__ | __\ue8df__ |
+| ![Telerik UI for .NET MAUI example font icon: emoji](images/emoji.png) | emoji | __\&#xe900;__ | __\ue900__ |
+| ![Telerik UI for .NET MAUI example font icon: brightness](images/brightness.png) | brightness | __\&#xe901;__ | __\ue901__ |
+| ![Telerik UI for .NET MAUI example font icon: flip-vertical](images/flip-vertical.png) | flip-vertical | __\&#xe902;__ | __\ue902__ |
+| ![Telerik UI for .NET MAUI example font icon: flip-horizontal](images/flip-horizontal.png) | flip-horizontal | __\&#xe903;__ | __\ue903__ |
+| ![Telerik UI for .NET MAUI example font icon: rotate-cw](images/rotate-cw.png) | rotate-cw | __\&#xe904;__ | __\ue904__ |
+| ![Telerik UI for .NET MAUI example font icon: rotate-ccw](images/rotate-ccw.png) | rotate-ccw | __\&#xe905;__ | __\ue905__ |
+| ![Telerik UI for .NET MAUI example font icon: crop](images/crop.png) | crop | __\&#xe906;__ | __\ue906__ | 
+| ![Telerik UI for .NET MAUI example font icon: hue](images/hue.png) | hue | __\&#xe907;__ | __\ue907__ |
+| ![Telerik UI for .NET MAUI example font icon: link-external](images/link-external.png) | link-external | __\&#xf08e;__ | __\uf08e__ |
+| ![Telerik UI for .NET MAUI example font icon: plus-squared](images/plus-squared.png) | plus-squared | __\&#xf0fe;__ | __\uf0fe__ |
+| ![Telerik UI for .NET MAUI example font icon: angle-left](images/angle-left.png) | angle-left | __\&#xf104;__ | __\uf104__ |
+| ![Telerik UI for .NET MAUI example font icon: angle-right](images/angle-right.png) | angle-right | __\&#xf105;__ | __\uf105__ |
+| ![Telerik UI for .NET MAUI example font icon: angle-up](images/angle-up.png) | angle-up | __\&#xf106;__ | __\uf106__ |
+| ![Telerik UI for .NET MAUI example font icon: angle-down](images/angle-down.png) | angle-down | __\&#xf107;__ | __\uf107__ |
+| ![Telerik UI for .NET MAUI example font icon: spinner](images/spinner.png) | spinner | __\&#xf110;__ | __\uf110__ |
+| ![Telerik UI for .NET MAUI example font icon: arrow-circled-left](images/arrow-circled-left.png) | arrow-circled-left | __\&#xf137;__ | __\uf137__ |
+| ![Telerik UI for .NET MAUI example font icon: arrow-circled-right](images/arrow-circled-right.png) | arrow-circled-right | __\&#xf138;__ | __\uf138__ |
+| ![Telerik UI for .NET MAUI example font icon: minus-squared](images/minus-squared.png) | minus-squared | __\&#xf146;__ | __\uf146__ |
+| ![Telerik UI for .NET MAUI example font icon: minus-squared-alt](images/minus-squared-alt.png) | minus-squared-alt | __\&#xf147;__ | __\uf147__ |
+| ![Telerik UI for .NET MAUI example font icon: plus-squared-alt](images/plus-squared-alt.png) | plus-squared-alt | __\&#xf196;__ | __\uf196__ |
 
 
 

--- a/introduction.md
+++ b/introduction.md
@@ -150,7 +150,7 @@ By clicking on each control you will navigate to the detailed .NET MAUI document
 - **Regular Updates**&mdash;Stays aligned with Microsoft's .NET MAUI releases and includes new features quarterly.
 - **Dedicated Support**&mdash;Technical support, community forums, and extensive documentation included.
 
-**Telerik UI for .NET MAUI introduction video overview**
+>caption Telerik UI for .NET MAUI introduction video overview
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/x0fY4qwkBTk?si=ULFP7NkbskhG9DEb" title="Introduction to Telerik UI for .NET MAUI: Course Overview and Prerequisites" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 

--- a/introduction.md
+++ b/introduction.md
@@ -26,7 +26,7 @@ Choose a path based on what you need:
 
 >tip This documentation covers the latest version of Telerik UI for .NET MAUI. For earlier versions, download the [offline PDF documentation](#learning-resources) from your Telerik account.
 
-![Telerik UI for .NET MAUI documentation](front-image.png)
+![Telerik UI for .NET MAUI documentation landing page highlighting cross-platform controls and getting started resources.](front-image.png)
 
 ## List of .NET MAUI UI Controls
 
@@ -149,6 +149,8 @@ By clicking on each control you will navigate to the detailed .NET MAUI document
 - **Saves Development Time**&mdash;Ready-to-use, feature-rich components let you focus on app logic instead of UI details.
 - **Regular Updates**&mdash;Stays aligned with Microsoft's .NET MAUI releases and includes new features quarterly.
 - **Dedicated Support**&mdash;Technical support, community forums, and extensive documentation included.
+
+**Telerik UI for .NET MAUI introduction video overview**
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/x0fY4qwkBTk?si=ULFP7NkbskhG9DEb" title="Introduction to Telerik UI for .NET MAUI: Course Overview and Prerequisites" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 

--- a/knowledge-base/combobox-calculate-dropdown-width.md
+++ b/knowledge-base/combobox-calculate-dropdown-width.md
@@ -33,7 +33,7 @@ For example, let's say the first 49 items are only five characters wide, but the
 
 Here is a visual mockup of how such a viewport works
 
-![](./images/combobox-calculate-dropdown-width-1.png)
+![Telerik UI for .NET MAUI ComboBox dropdown width behavior showing narrow initial items and a wider item appearing later in the virtualized list.](./images/combobox-calculate-dropdown-width-1.png)
 
 So, if you want the same width with the widest item, then you'll need to determine this ahead of time and set the `DropDownWidth` property to the widest value.
 


### PR DESCRIPTION
After inspecting the top 100 most visited articles for 2026 (DataGrid is the most visited control), the conclusion is that the MAUI team follows a good practice for introducing the code snippet with a description or an intro sentence. Almost all images contain alt text (those alt texts that were missing it , have been added). Some of the alt texts have been improved. The whole DataGrid section was improved in terms of alt image tags and code snippet descriptions.

Recommendation for automating the verification for every PR in future: Add a skill in the docs repo that will be used by the Copilot reviewer. This is expected to check the image alt tags if they are missing or if they are correct, describing the image. It will also ensure that a comprehensive description or introduction to code snippets and examples is added. Several useful skills can be found here: https://github.com/telerik/dt-content/tree/master/dmcd-agents/.github/skills