### PR TITLE
Common: Fix API names, property names, and localization keys discovered during component skill authoring

### DIFF
--- a/controls/calendar/navigation.md
+++ b/controls/calendar/navigation.md
@@ -26,8 +26,8 @@ The user can interact with the UI and navigate to the parent view by tapping or 
 
 To restrict the navigation depth to specific parent or child views, use the following properties:
 
-* `MinDisplayMode`(`Telerik.Maui.controls.Calendar.CalendarDisplayMode`)&mdash;Specifies the minimum display mode of the Calendar.
-* `MaxDisplayMode`(`Telerik.Maui.controls.Calendar.CalendarDisplayMode`)&mdash;Specifies the maximum display mode of the Calendar.
+* `MinDisplayMode`(`Telerik.Maui.Controls.Calendar.CalendarDisplayMode`)&mdash;Specifies the minimum display mode of the Calendar.
+* `MaxDisplayMode`(`Telerik.Maui.Controls.Calendar.CalendarDisplayMode`)&mdash;Specifies the maximum display mode of the Calendar.
 
 ## Setting the Scroll Direction
 

--- a/controls/calendar/styling/content-styling.md
+++ b/controls/calendar/styling/content-styling.md
@@ -54,7 +54,7 @@ The `CalendarNode` class has the information for:
 * `IsToday`(`bool`)&mdash;Gets a value indicating whether the date is today.
 * `IsMouseOver`(`bool`)&mdash;Gets a value indicating whether the mouse is over the date.
 * `IsVisible`(`bool`)&mdash;Gets a value indicating whether the node is visible.
-* `SelectionState`(enum of type `Telerik.Maui.controls.Calendar.CalendarNodeSelectionState`)&mdash;Gets a value indicating the state of the date when selected. The options are: `None`, `Single`, `Middle`, `First` and `Last`.
+* `SelectionState`(enum of type `Telerik.Maui.Controls.Calendar.CalendarNodeSelectionState`)&mdash;Gets a value indicating the state of the date when selected. The options are: `None`, `Single`, `Middle`, `First` and `Last`.
 
 The following example demonstrates the `CustomStyleSelector` class that inherits from `CalendarStyleSelector`:
 

--- a/controls/chart/behaviors/pan-and-zoom-behavior.md
+++ b/controls/chart/behaviors/pan-and-zoom-behavior.md
@@ -24,7 +24,7 @@ The Pan and Zoom behavior of the Chart handles the drag, pinch open, and pinch c
 	- `Horizontal`
 	- `Vertical`
 	- Both
-- `HandleDoubleTap`&mdash;Determines whether a double-tap gesture will be handled by the behavior to reset the values of the `Zoom` and `ScrollOffset` (`Pan`) properties of the chart.
+- `HandleDoubleTap`&mdash;Determines whether a double-tap gesture will be handled by the behavior to reset the values of the `Zoom` and `PanOffset` properties of the chart.
 
 ## Example
 

--- a/controls/chart/behaviors/selection-behavior.md
+++ b/controls/chart/behaviors/selection-behavior.md
@@ -29,10 +29,12 @@ The Selection behavior supports the following properties:
 	-  `Multiple`
 - `SelectedPoints`&mdash;Retrieves all the points from all currently selected series within the chart plot area.
 - `SelectedSeries`&mdash;Retrieves all currently selected series instances within the plot area.
+- `Command`&mdash;Gets or sets the `ICommand` invoked when selection changes.
+- `CommandParameter`&mdash;Gets or sets the optional parameter passed to `Command`.
 
 ### Methods
 
-The Selection behavior supports the `ClearSelecton()` method, which removes the current selection within the chart.
+The Selection behavior supports the `ClearSelection()` method, which removes the current selection within the chart.
 
 ### Events
 
@@ -40,7 +42,7 @@ The Selection behavior supports the `SelectionChanged` event, which occurs when 
 
 ### Commands
 
-The Selection behavior supports the `Commands` selection.
+The Selection behavior supports the `Command` and `CommandParameter` properties.
 
 ## Example
 

--- a/controls/chart/legend.md
+++ b/controls/chart/legend.md
@@ -33,7 +33,7 @@ The following list summarizes the most important properties of the `RadLegend` c
 * `LegendItemFontSize` (`double`)&mdash;The size of the item's title text.
 * `LegendItemFontColor` (`Color`)&mdash;The color of the item's title text.
 * `LegendItemIconSize` (`Size`)&mdash;The size of the title icons.
-* `Orientation` (`LegndOrientation`)&mdash;Sets the orientation of the legend. Can be `Horizontal` or `Vertical`.
+* `Orientation` (`LegendOrientation`)&mdash;Sets the orientation of the legend. Can be `Horizontal` or `Vertical`.
 
 `RadLegend` can be used in combination with `RadCartesianChart` as well.
 

--- a/controls/chart/series/financial/financial-indicators.md
+++ b/controls/chart/series/financial/financial-indicators.md
@@ -16,7 +16,7 @@ When setting their properties and getting them ready for displaying your stock d
 
 * Indicators that have a category and a value binding (usually the **close** one) as well as one or more periods:  
 
-  * `OscillatorIndicator`
+  * `MovingAverageIndicator`
   * `RateOfChangeIndicator`
   * `RelativeStrengthIndexIndicator`
   * `TrixIndicator`

--- a/controls/chart/types/pie-chart.md
+++ b/controls/chart/types/pie-chart.md
@@ -16,7 +16,7 @@ The Pie Chart visualizes its data points by using the radial coordinate system. 
 The Pie Chart supports the following properties:
 
 * `Series`&mdash;Gets a collection of all series presented by the chart instance.
-* `Behaviors`&mdash;Gets a collection of all enabled behaviors.
+* `ChartBehaviors`&mdash;Gets a collection of all enabled behaviors.
 * `Palette`&mdash;Gets or sets the `ChartPalette` instance that defines the appearance of the chart.
 * `PaletteName`&mdash;Gets or sets the name of the predefined `Palette` that will be applied to the chart.
 * `SelectionPalette`&mdash;Gets or sets the `ChartPalette` instance that defines the appearance of the chart for the selected series and/or data points.

--- a/controls/datagrid/localization.md
+++ b/controls/datagrid/localization.md
@@ -48,6 +48,7 @@ The table below shows the localization keys available for the DataGrid control a
 | `DataGrid_Search_MatchesNotfound` | `Not found` |
 | `DataGrid_Search_MatchesStringFormat` | `Matches: {0}` |
 | `DataGrid_Search_SearchEntryPlaceholder` | `Type to Search` |
+| `DataGrid_Search_StartsWith` | `Starts With` |
 | `DataGrid_Search_WholeWord` | `Whole Word` |
 | `DataGrid_AI_InputView_Placeholder` | `Sort, filter, or group with AI` |
 | `DataGrid_AI_InputView_Thinking` | `Thinking...` |
@@ -56,6 +57,17 @@ The table below shows the localization keys available for the DataGrid control a
 | `DataGrid_AI_PromptInputView_NoSuggestionsLabel` | `No previous prompts` |
 | `DataGrid_AI_SheetContent_HeaderLabel` | `Ask AI` |
 | `DataGrid_AI_FloatingActionButton_Text` | `AI Grid` |
+| `DataGrid_AI_Search_Placeholder` | `Search...` |
+| `DataGrid_AI_Semantic_Search_Placeholder` | `Semantic search...` |
+| `DataGrid_AI_SearchView_RecentSearchesLabel` | `Previously Searched` |
+| `DataGrid_AI_SearchView_SearchOptionTitle` | `Search` |
+| `DataGrid_AI_SearchView_SearchOptionDescription` | `Looks for exact word matches across data` |
+| `DataGrid_AI_SearchView_SemanticSearchOptionTitle` | `Semantic Search` |
+| `DataGrid_AI_SearchView_SemanticSearchOptionDescription` | `Understands context to surface the most relevant results` |
+| `DataGrid_AI_ViewMode_Search` | `Search` |
+| `DataGrid_AI_ViewMode_AIAssistant` | `AI Assistant` |
+| `DataGrid_AI_EmptyContent_Search` | `No previous searches` |
+| `DataGrid_AI_EmptyContent_AIAssistant` | `No previous prompts` |
 
 ## Additional Resources
 

--- a/controls/datepicker/styling/dropdown-styling.md
+++ b/controls/datepicker/styling/dropdown-styling.md
@@ -15,7 +15,7 @@ To modify the appearance of the DatePicker drop-down element, use the `DropDownS
 The `PickerDropDownSettings` class exposes the following `Style` properties:
 
 * `DropDownViewStyle`(of type `Style` with target type `telerik:PickerDropDownContentView`)&mdash;Defines the drop-down view style.
-* `FooterStyle`(of type `Style` with target type `telerik:PickerPopupFooterView`)&mdash;Defines the drop-down footer style.
+* `FooterStyle`(of type `Style` with target type `telerik:PickerDropDownFooterView`)&mdash;Defines the drop-down footer style.
 * `AcceptButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Accept** button style.
 * `CancelButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Cancel** button style.
 

--- a/controls/datepicker/visual-structure.md
+++ b/controls/datepicker/visual-structure.md
@@ -26,7 +26,7 @@ The images in this article show the anatomy of the DatePicker and its building b
 
 - **Header**&mdash;The text that is displayed in the popup header. You can set it to a text input through the [`HeaderLabelText`]({%slug datepicker-styling%}#styling) property, or customize it by using the [`HeaderTemplate`]({%slug datepicker-templates%}#headertemplate) property.
 - **Header Text**&mdash;The text that is visualized in the header of the popup.
-- **Spinners Header**&mdash;The text that is visualized for each spinner header. For example, if the `SpinnerFormatString` is `d`, the visualized text for the spinner header will be `Month` `Day` `Year`.
+- **Spinners Header**&mdash;The text that is visualized for each spinner header. For example, if the `SpinnerFormat` is `d`, the visualized text for the spinner header will be `Month` `Day` `Year`.
 - **Spinners**&mdash;Displays items in a list. For `d` format, three spinners will be visualized: one for month, one for day, and one for year.
 - **SelectionHighlight**&mdash;Highlights the current selected date when the popup is open.
 - **Footer**&mdash;The footer of the popup. By default, it contains the **OK** and **Cancel** buttons. You can customize it through the [`FooterTemplate`]({%slug datepicker-templates%}#footertemplate) property.

--- a/controls/datetimepicker/styling/dropdown-styling.md
+++ b/controls/datetimepicker/styling/dropdown-styling.md
@@ -11,7 +11,7 @@ slug: datetimepicker-dropdown-styling
 By using the `DropDownSettings` property (of type `Telerik.Maui.Controls.PickerDropDownSettings`) of the DateTimePicker, you can modify the appearance of the drop-down. The `PickerDropDownSettings` class exposes the following `Style` properties:
 
 * `DropDownViewStyle`(of type `Style` with target type `telerik:PickerDropDownContentView`)&mdash;Defines the drop-down view style.
-* `FooterStyle`(of type `Style` with target type `telerik:PickerPopupFooterView`)&mdash;Defines the drop-down footer style.
+* `FooterStyle`(of type `Style` with target type `telerik:PickerDropDownFooterView`)&mdash;Defines the drop-down footer style.
 * `AcceptButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Accept** button style.
 * `CancelButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Cancel** button style.
 

--- a/controls/datetimepicker/visual-structure.md
+++ b/controls/datetimepicker/visual-structure.md
@@ -26,7 +26,7 @@ The images in this article show the anatomy of the DateTimePicker and its buildi
 - **Header**&mdash;The text that is displayed in the popup header. You can set it to a text input through the [`HeaderLabelText`]({%slug datetimepicker-styling%}#styling) property, or customize it by using the [`HeaderTemplate`]({%slug datetimepicker-templates%}#headertemplate) property.
 - **Date Tab**&mdash;Represents the date section of the popup.
 - **Time Tab**&mdash;Represents the time section of the popup.
-- **Spinners Header**&mdash;The text that is visualized for the spinner header depending on the values that are picked. For example, if the `SpinnerFormatString` is `d`, and `AreSpinnerHeadersVisible` property is set to `True` the visualized text for the spinner header will be `Month` ,`Day`,`Year`.
+- **Spinners Header**&mdash;The text that is visualized for the spinner header depending on the values that are picked. For example, if the `SpinnerFormat` is `d`, and `AreSpinnerHeadersVisible` property is set to `True` the visualized text for the spinner header will be `Month` ,`Day`,`Year`.
 - **Spinners**&mdash;Displays items in a list. For `d` format, three spinners will be visualized: one for month, one for day, and one for year.
 - **SelectionHighlight**&mdash;Highlights the current selected date and time when the popup is open.
 - **Footer**&mdash;The footer of the popup. By default, it contains the **OK** and **Cancel** buttons. You can customize it through the [`FooterTemplate`]({%slug datetimepicker-templates%}#footertemplate) property.

--- a/controls/imageeditor/commands.md
+++ b/controls/imageeditor/commands.md
@@ -90,7 +90,7 @@ Commands which cancel/apply the changes made in interactive commands:
 
 * `RedoCommand`(`ICommand`)&mdash;Gets the command for the redo action.
 
-* `ResetCommnad`(`ICommand`)&mdash;Reset all changes applied to the image.
+* `ResetCommand`(`ICommand`)&mdash;Reset all changes applied to the image.
 
 * `RotateBackwardCommand`(`ICommand`)&mdash;Rotates the image backwards.
 

--- a/controls/imageeditor/zooming-image.md
+++ b/controls/imageeditor/zooming-image.md
@@ -10,12 +10,12 @@ slug: imageeditor-zooming-image
 
 This article explains what are the zooming options you can apply to the image in the ImageEditor. The properties related to the zooming are:
 
-* `ZoomLevel`(`double`)&mdash;Specifies the current zoom level of the viewed image. The default value is 1. A zoom level of 1 means the image is displayed with its original size. 
+* `ZoomLevel`(`double`)&mdash;Specifies the current zoom level of the viewed image in percent. The default value is 100. A zoom level of 100 means the image is displayed with its original size. 
 
 In addition, you can restrict the zooming by applying min and max zoom: 
 
-* `MinZoomLevel`(`double`)&mdash;Specifies the minimum allowed zoom level of the image. The default value is 0.01. Setting the `ZoomLevel` property is coerced between `MinZoomLevel` and `MaxZoomLevel`.
-* `MaxZoomLevel`(`double`)&mdash;Specifies the maximum allowed zoom level of the image. The default value is 10.0. Setting the `ZoomLevel` property is coerced between `MinZoomLevel` and `MaxZoomLevel`.
+* `MinZoomLevel`(`double`)&mdash;Specifies the minimum allowed zoom level of the image in percent. The default value is 1. Setting the `ZoomLevel` property is coerced between `MinZoomLevel` and `MaxZoomLevel`.
+* `MaxZoomLevel`(`double`)&mdash;Specifies the maximum allowed zoom level of the image in percent. The default value is 1000. Setting the `ZoomLevel` property is coerced between `MinZoomLevel` and `MaxZoomLevel`.
 
 
 **Example with Min and Max Zoom levels**

--- a/controls/listpicker/styling/dropdown-styling.md
+++ b/controls/listpicker/styling/dropdown-styling.md
@@ -8,10 +8,10 @@ slug: listpicker-dropdown-styling
 
 # .NET MAUI ListPicker DropDown Styling
 
-By using the `DropDownSettings` property (of type `Telerik.Maui.controls.PickerDropDownSettings`) of the ListPicker, you can modify the appearance of the dropdown. The `PickerDropDownSettings` class exposes the following `Style` properties:
+By using the `DropDownSettings` property (of type `Telerik.Maui.Controls.PickerDropDownSettings`) of the ListPicker, you can modify the appearance of the dropdown. The `PickerDropDownSettings` class exposes the following `Style` properties:
 
 * `DropDownViewStyle`(of type `Style` with target type `telerik:PickerDropDownContentView`)&mdash;Defines the dropdown view style.
-* `FooterStyle`(of type `Style` with target type `telerik:PickerPopupFooterView`)&mdash;Defines the dropdown footer style.
+* `FooterStyle`(of type `Style` with target type `telerik:PickerDropDownFooterView`)&mdash;Defines the dropdown footer style.
 * `AcceptButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Accept** button style.
 * `CancelButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Cancel** button style.
 

--- a/controls/listpicker/styling/popup-styling.md
+++ b/controls/listpicker/styling/popup-styling.md
@@ -74,7 +74,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
  ```
 
 
-The following image shows what the DateTimePicker control looks like when the styles described above are applied:
+The following image shows what the ListPicker control looks like when the styles described above are applied:
 
 ![ListPicker Popup Styling](../images/listpicker_popupstyle.png)
 

--- a/controls/progressbar/migrate-from-xamarin.md
+++ b/controls/progressbar/migrate-from-xamarin.md
@@ -15,7 +15,7 @@ Telerik .NET MAUI ProgressBar control preserves the same API as Xamarin.Forms Pr
 | Control | Control name | XAML Namespcace | C# Namespace|
 | --------------- | --------------- | --------------- | --------------- |
 | Xamarin ProgressBar | `RadProgressBar` | xmlns:telerikPrimitives="clr-namespace:Telerik.XamarinForms.Primitives;assembly=Telerik.XamarinForms.Primitives" | using Telerik.XamarinForms.Primitives; |
-| .NET MAUI ProgressBar | `RadProgressBar` | xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"` | using Telerik.Maui.Controls; |
+| .NET MAUI ProgressBar | `RadLinearProgressBar` | xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"` | using Telerik.Maui.Controls; |
 
 ## Modifying the API
 

--- a/controls/richtexteditor/localization.md
+++ b/controls/richtexteditor/localization.md
@@ -68,7 +68,7 @@ The [.NET MAUI RichTextEditor]({%slug richtexteditor-overview%}) provides langua
 | `RichTextEditor_OpenHyperlink` | `Open Hyperlink` |
 | `RichTextEditor_OpenHyperlinkContextMenuText` | `Open` |
 | `RichTextEditor_OpenHyperlinkErrorHeaderText` | `Error` |
-| `RichTextEditor_OpenHyperlinkErrorOKButtonText` | `Ok` |
+| `RichTextEditor_OpenHyperlinkErrorOKButtonText` | `OK` |
 | `RichTextEditor_OpenHyperlinkErrorText` | `Cannot open url:` |
 | `RichTextEditor_OrderedList` | `Ordered Indent` |
 | `RichTextEditor_Paragraph` | `Paragraph` |
@@ -81,7 +81,7 @@ The [.NET MAUI RichTextEditor]({%slug richtexteditor-overview%}) provides langua
 | `RichTextEditor_RemoveHyperlink` | `Remove Hyperlink` |
 | `RichTextEditor_RemoveImage` | `Remove Image` |
 | `RichTextEditor_PickImage` | `Pick Image` |
-| `RichTextEditor_SelectAllContextMenuText`  | `Select Al` |
+| `RichTextEditor_SelectAllContextMenuText`  | `Select All` |
 | `RichTextEditor_Strike` | `Strike` |
 | `RichTextEditor_Subscript` | `Subscript` |
 | `RichTextEditor_Superscript` | `Superscript` |

--- a/controls/scheduler/localization.md
+++ b/controls/scheduler/localization.md
@@ -20,8 +20,13 @@ The table below shows the localization keys:
 | `Scheduler_MultidayViewDefinition_Title` | `Multiday` |
 | `Scheduler_DayViewDefinition_Title`  | `Day` |
 | `Scheduler_MonthViewDefinition_Title` | `Month` |
+| `Scheduler_AgendaViewDefinition_Title` | `Agenda` |
+| `Scheduler_AgendaViewDefinition_AllDay` | `All day` |
+| `Scheduler_AgendaViewDefinition_Until` | `Until` |
+| `Scheduler_AgendaViewDefinition_Appointment_Day` | `Day` |
 | `Scheduler_Today_Header_Text` | `Today` |
 | `Scheduler_Empty_ViewDefinition_Text` | `Please declare a View definition` |
+| `Scheduler_CreateAppointmentDialog_Header` | `New Appointment` |
 | `Scheduler_EditAppointmentDialog_Subject` | `Subject`|
 | `Scheduler_EditAppointmentDialog_StartTime` | `Start Time` |
 | `Scheduler_EditAppointmentDialog_EndTime` | `End Time` |
@@ -79,10 +84,13 @@ The table below shows the localization keys:
 | `Scheduler_ConfirmDeleteDialog_Question_Series` | `Are you sure you want to delete the series?` |
 | `Scheduler_ConfirmDeleteDialog_Delete` | `Delete` |
 | `Scheduler_ConfirmDeleteDialog_Cancel` | `Cancel` |
-| `Scheduler_DeleteAppointmentChoiceDialog_Header` | `Delete Appointment"` |
+| `Scheduler_DeleteAppointmentChoiceDialog_Header` | `Delete Appointment` |
+| `Scheduler_DeleteAppointmentChoiceDialog_Question_Occurrence` | `Are you sure you want to delete this occurrence?` |
 | `Scheduler_DeleteAppointmentChoiceDialog_Question_Appointment` | `Are you sure you want to delete this appointment?` |
+| `Scheduler_DeleteAppointmentChoiceDialog_Question_Series` | `Are you sure you want to delete the series?` |
 | `Scheduler_DeleteAppointmentChoiceDialog_Delete` | `Delete` |
-| `"Scheduler_DeleteAppointmentChoiceDialog_Cancel` | `Cancel` |
+| `Scheduler_DeleteAppointmentChoiceDialog_Cancel` | `Cancel` |
+| `Scheduler_DeleteRecurrenceChoiceDialog_Header` | `Delete Appointment` |
 | `Scheduler_DeleteRecurrenceChoiceDialog_Delete_Occurrence` | `Delete this occurrence.` |
 | `Scheduler_DeleteRecurrenceChoiceDialog_Delete_Series` | `Delete the series.` |
 | `Scheduler_DeleteRecurrenceChoiceDialog_Delete` | `Delete` |

--- a/controls/sidedrawer/transitions.md
+++ b/controls/sidedrawer/transitions.md
@@ -12,7 +12,7 @@ Transitions are the animation effects applied to the side drawer while being ope
 
 * `DrawerTransitionDuration`(`double`)&mdash;Defines the duration of the chosen transition.
 * `DrawerTransitionType`(enum of type `Telerik.Maui.Controls.SideDrawerTransitionType`)&mdash;Defines the transition of the component. This property can be set to one of the following values: 
-	* `Fade`, `Push`, `Reveal`, `ReverseSlideOut`, `ScaleUp`, `SlideAling`, `SlideInOnTop`, `Custom`
+	* `Fade`, `Push`, `Reveal`, `ReverseSlideOut`, `ScaleUp`, `SlideAlong`, `SlideInOnTop`, `Custom`
 	
 * `DrawerTransitionFadeOpacity`(`double`)&mdash;Defines the opacity of the fade layer of the component. This controls the fade layer opacity on Android and WinUI or the dim opacity on iOS and MacCatalyst. The opacity value is different on different platforms. Review the [Making SideDrawer Opacity Consistent across Platforms]({%slug make-sidedrawer-opacity-consistent-across-platforms-net-maui%}) how-to article for more details.
 

--- a/controls/slideview/indicators.md
+++ b/controls/slideview/indicators.md
@@ -29,8 +29,8 @@ The following table represents the properties of the `SlideViewIndicator`.
 |--------|------------|
 | `HasLooping`|Defines a value that indicates whether the navigation commands can navigate from the first to the last and from the last to the first items.|
 | `Orientation`|Defines the orientation of the control.|
-| `NavigationButtonsVisibillity`|Defines a value that controls the visibility of the navigation buttons.|
-| `NavigatеOnItemTap`|Defines a value indicating whether tapping on an item will update the current index of the SlideViewIndicator and whether navigation will follow.|
+| `NavigationButtonsVisibility`|Defines a value that controls the visibility of the navigation buttons.|
+| `NavigateOnItemTap`|Defines a value indicating whether tapping on an item will update the current index of the SlideViewIndicator and whether navigation will follow.|
 | `AnimationDuration`(`int`)|Defines the duration (in milliseconds) of the animation that runs when the current index changes.|
 | `AnimationEasing`(`Easing`)|Defines the `Microsoft.Maui.Easing` of the animation that runs when the current index changes.|
 | `CurrentIndex`|Defines the index of the current item.|

--- a/controls/slideview/navigation-buttons.md
+++ b/controls/slideview/navigation-buttons.md
@@ -10,7 +10,7 @@ slug: slideview-interaction
 
 To switch through the different views of the SlideView, you can use Navigation Buttons. On `WinUI` and `MacCatalyst` the buttons are visible by default. On `Android` and `iOS` the buttons are hidden.
 
-The SlideView exposes a `NavigationButtonVisibility` property that allows you to control the visibility options of the Navigation Buttons:
+The SlideView exposes a `NavigationButtonsVisibility` property that allows you to control the visibility options of the Navigation Buttons:
 
 * `Visible`&mdash;The buttons are visible. 
 

--- a/controls/tabview/xamarin-migration.md
+++ b/controls/tabview/xamarin-migration.md
@@ -37,7 +37,7 @@ When migrating the TabView from Xamarin to .NET MAUI, consider the following dif
 | `IsScrollable` | `IsHeaderScrollable` |
 | N/A | `IsHeaderOverlaid` |
 | Overflow button | N/A |
-| `IsContentSwipingEnabled` | `IsContentSwipingEnabled` |
+| `IsContentSwipingEnabled` | `IsContentSwipeEnabled` |
 | `TabViewItem` | `TabViewItem` |
 | N/A | `HeaderStyle` |
 | N/A | `HeaderItemStyle` |

--- a/controls/templatedpicker/localization.md
+++ b/controls/templatedpicker/localization.md
@@ -14,8 +14,8 @@ The Telerik .NET MAUI TemplatedPicker exposes localization keys explained in the
 
 | Localization Key | Default Value |
 | -----------------| ------------- |
-| `TemplatedPicker_PlaceholderLabelText`  | `Select value` |
-| `TemplatedPicker_Popup_HeaderLabelText` | `Select value` |
+| `TemplatedPicker_PlaceholderLabelText`  | `Select Value` |
+| `TemplatedPicker_Popup_HeaderLabelText` | `Select Value` |
 
 **Common Picker localization keys**
 

--- a/controls/templatedpicker/styling/dropdown-styling.md
+++ b/controls/templatedpicker/styling/dropdown-styling.md
@@ -11,7 +11,7 @@ slug: templatedpicker-dropdown-styling
 By using the `DropDownSettings` property (of type `Telerik.Maui.Controls.PickerDropDownSettings`) of the TemplatedPicker, you can modify the appearance of the dropdown. The `PickerDropDownSettings` class exposes the following `Style` properties:
 
 * `DropDownViewStyle`(of type `Style` with target type `telerikInput:PickerDropDownContentView`)&mdash;Defines the dropdown view style.
-* `FooterStyle`(of type `Style` with target type `telerikInput:PickerPopupFooterView`)&mdash;Defines the dropdown footer style.
+* `FooterStyle`(of type `Style` with target type `telerikInput:PickerDropDownFooterView`)&mdash;Defines the dropdown footer style.
 * `AcceptButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Accept** button style.
 * `CancelButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Cancel** button style.
 

--- a/controls/templatedpicker/styling/popup-styling.md
+++ b/controls/templatedpicker/styling/popup-styling.md
@@ -8,7 +8,7 @@ slug: templatedpicker-popup-styling
 
 # .NET MAUI TemplatedPicker Popup Styling
 
-By using the `PopupSettings` property (of type `Telerik.Maui.Controls.PickerPopupSettings`) of the TimePicker, you can modify the appearance of the dialog (popup).
+By using the `PopupSettings` property (of type `Telerik.Maui.Controls.PickerPopupSettings`) of the TemplatedPicker, you can modify the appearance of the dialog (popup).
 
 The `PickerPopupSettings` class exposes the following `Style` properties:
 
@@ -72,13 +72,13 @@ In addition, add the following namespace:
 xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 ```
 
-The following image shows how the TimePicker control looks when the styles described above are applied.
+The following image shows how the TemplatedPicker control looks when the styles described above are applied.
 
 ![TemplatedPicker Popup Style](../images/templatedpicker_popupstyle.png)
 
 ## See Also
 
-- [TimePicker Styling]({%slug timepicker-styling%})
-- [Custom Templates]({%slug timepicker-templates%})
-- [Commands]({%slug timepicker-commands%})
-- [Visual Structure]({%slug timepicker-visual-structure%})
+- [TemplatedPicker Styling]({%slug templatedpicker-styling%})
+- [Custom Templates]({%slug templatedpicker-templates%})
+- [Commands]({%slug templatedpicker-commands%})
+- [Visual Structure]({%slug templatedpicker-visual-structure%})

--- a/controls/timepicker/styling/dropdown-styling.md
+++ b/controls/timepicker/styling/dropdown-styling.md
@@ -11,7 +11,7 @@ slug: timepicker-dropdown-styling
 By using the `DropDownSettings` property (of type `Telerik.Maui.Controls.PickerDropDownSettings`) of the TimePicker, you can modify the appearance of the dropdown. The `PickerDropDownSettings` class exposes the following `Style` properties:
 
 * `DropDownViewStyle`(of type `Style` with target type `telerik:PickerDropDownContentView`)&mdash;Defines the dropdown view style.
-* `FooterStyle`(of type `Style` with target type `telerik:PickerPopupFooterView`)&mdash;Defines the dropdown footer style.
+* `FooterStyle`(of type `Style` with target type `telerik:PickerDropDownFooterView`)&mdash;Defines the dropdown footer style.
 * `AcceptButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Accept** button style.
 * `CancelButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Cancel** button style.
 
@@ -23,7 +23,7 @@ The `DropDownSettings` also provides the following properties for dropdown custo
 * `AcceptButtonText`(`string`)&mdash;Defines the text visualized for the **Accept** button. By default, the text is `OK`.
 * `CancelButtonText`(`string`)&mdash;Defines the text visualized for the **Cancel** button. By default, the text is `Cancel`.
 
-> __DropDownSettings__ provides styling options for the dropdown, its footer and position, and other. If you need to customize the look&feel of the spinner controls that show the available date values, please refer to `SpinnerStyle`, `SpinnerHeaderStyle` and `SelectionHighlightStyle` properties of the TimePicker. For more detailed information on them go to [TimePicker Styling]({%slug timepicker-styling%}) topic.
+> __DropDownSettings__ provides styling options for the dropdown, its footer and position, and other. If you need to customize the look&feel of the spinner controls that show the available time values, please refer to `SpinnerStyle`, `SpinnerHeaderStyle` and `SelectionHighlightStyle` properties of the TimePicker. For more detailed information on them go to [TimePicker Styling]({%slug timepicker-styling%}) topic.
 
 ## Example
 

--- a/controls/timepicker/visual-structure.md
+++ b/controls/timepicker/visual-structure.md
@@ -26,7 +26,7 @@ The images in this article show the anatomy of the TimePicker and its building b
 
 - **Header**&mdash;The text displayed in the popup header. You can set it to a direct text input through the [`HeaderLabelText`]({%slug timepicker-styling%}#popup-styling) property or customize the popup header by using the [`HeaderTemplate`]({%slug timepicker-templates%}#headertemplate) property.
 - **Header Text**&mdash;The text that is visualized in the header of the popup.
-- **SpinnerHeader**&mdash;The text visualized for the spinner header depending on the values that are picked. For example, if the `SpinnerFormatString` is `g` and `AreSpinnerHeadersVisible="True"`, the text visualized for the spinner header will be **Hour** **Minutes** **AM/PM**.
+- **SpinnerHeader**&mdash;The text visualized for the spinner header depending on the values that are picked. For example, if the `SpinnerFormat` is `g` and `AreSpinnerHeadersVisible="True"`, the text visualized for the spinner header will be **Hour** **Minutes** **AM/PM**.
 - **Spinner**&mdash;Displays items in a list.
 - **SelectionHighlight**&mdash;Highlights the currently selected time when the popup is open.
 - **Footer**&mdash;The footer of the popup. By default, it contains the **OK** and **Cancel** buttons. It can be customized through the [`FooterTemplate`]({%slug timepicker-templates%}#footertemplate) property.

--- a/controls/timespanpicker/localization.md
+++ b/controls/timespanpicker/localization.md
@@ -6,9 +6,9 @@ position: 8
 slug: timespanpicker-localization
 ---
 
-# .NET MAUI ТimeSpanPicker Localization
+# .NET MAUI TimeSpanPicker Localization
 
-The ТimeSpanPicker for .NET MAUI provides language localization. The localization keys are described in the tables below:
+The TimeSpanPicker for .NET MAUI provides language localization. The localization keys are described in the tables below:
 
 >caption TimeSpanPicker localization keys
 

--- a/controls/timespanpicker/selection.md
+++ b/controls/timespanpicker/selection.md
@@ -31,7 +31,7 @@ xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
 
 ## Clear Button
 
-You can enable a Clear button which can be used to quickly remove the selected value. To enable the button, set ``IsClearButtonVisible`` property of the TimePicker:
+You can enable a Clear button which can be used to quickly remove the selected value. To enable the button, set ``IsClearButtonVisible`` property of the TimeSpanPicker:
 
 ```XAML
 <telerik:RadTimeSpanPicker Time="5:10:30:00"
@@ -70,7 +70,7 @@ private void OnClearSelectionClicked(object sender, EventArgs e)
 
 ## Events
 
-The TimeSpanPicker exposes the `SelectionChanged` event, which is raised when the user picks a time value.
+The TimeSpanPicker exposes the `SelectionChanged` event, which is raised when the user picks a time interval.
 
 The following example shows how to set the `SelectionChanged` event.
 

--- a/controls/timespanpicker/styling/dropdown-styling.md
+++ b/controls/timespanpicker/styling/dropdown-styling.md
@@ -6,24 +6,24 @@ position: 2
 slug: timespanpicker-dropdown-styling
 ---
 
-# .NET MAUI TimePicker DropDown Styling
+# .NET MAUI TimeSpanPicker DropDown Styling
 
 By using the `DropDownSettings` property (of type `Telerik.Maui.Controls.PickerDropDownSettings`) of the TimeSpanPicker, you can modify the appearance of the drop-down. The `PickerDropDownSettings` class exposes the following `Style` properties:
 
 * `DropDownViewStyle`(of type `Style` with target type `telerik:PickerDropDownContentView`)&mdash;Defines the dropdown view style.
-* `FooterStyle`(of type `Style` with target type `telerik:PickerPopupFooterView`)&mdash;Defines the dropdown footer style.
+* `FooterStyle`(of type `Style` with target type `telerik:PickerDropDownFooterView`)&mdash;Defines the dropdown footer style.
 * `AcceptButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Accept** button style.
 * `CancelButtonStyle`(of type `Style` with target type `Button`)&mdash;Defines the **Cancel** button style.
 
 The `DropDownSettings` also provides the following properties for dropdown customization:
 
 * `Placement`(of type `PlacementMode`)&mdash;Specifies the position of the dropdown, can be set to Bottom, Right, Left, Top, Center or Relative.
-* `HorizontalOffset` \ `VerticalOffset`&mdash;Specifies the horizontal\vertical distance between the dropdown and the TimePicker.
+* `HorizontalOffset` \ `VerticalOffset`&mdash;Specifies the horizontal\vertical distance between the dropdown and the TimeSpanPicker.
 * `IsFooterVisible`(`bool`)&mdash;Specifies whether the DropDown footer is currently visible. By default, the value is `True`.
 * `AcceptButtonText`(`string`)&mdash;Defines the text visualized for the **Accept** button. By default, the text is `OK`.
 * `CancelButtonText`(`string`)&mdash;Defines the text visualized for the **Cancel** button. By default, the text is `Cancel`.
 
-> `DropDownSettings` provides styling options for the drop-down, its footer and position, and other. If you need to customize the look&feel of the spinner controls that show the available date values, please refer to `SpinnerStyle`, `SpinnerHeaderStyle` and `SelectionHighlightStyle` properties of the TimeSpanPicker. For more detailed information on them go to [TimeSpanPicker Styling]({%slug timespanpicker-styling%}) topic.
+> `DropDownSettings` provides styling options for the drop-down, its footer and position, and other. If you need to customize the look&feel of the spinner controls that show the available time interval values, please refer to `SpinnerStyle`, `SpinnerHeaderStyle` and `SelectionHighlightStyle` properties of the TimeSpanPicker. For more detailed information on them go to [TimeSpanPicker Styling]({%slug timespanpicker-styling%}) topic.
 
 ## Example
 


### PR DESCRIPTION
## Change Summary

Fixes to API names, property names, enum members, and localization keys discovered while authoring AI coding assistant component skills. All changes correct documentation to match the actual source code.

- **Calendar** — corrected namespace casing for CalendarDisplayMode and CalendarNodeSelectionState (were lowercased in docs)
- **Chart** — fixed incorrect API names in multiple chart docs articles
- **Pickers** — fixed styling and naming issues across picker docs
- **SideDrawer** — corrected SlideAlong enum member typo in transitions docs
- **SlideView** — fixed property name typos in navigation buttons and indicators docs
- **TabView** — fixed IsContentSwipingEnabled typo in Xamarin migration docs
- **ImageEditor** — fixed ResetCommand typo (was ResetCommnad) and corrected ZoomLevel/MinZoomLevel/MaxZoomLevel to use percent scale (100/1/1000) matching source constants (docs incorrectly used 1-based multiplier scale)
- **ProgressBar** — corrected MAUI type name in migration doc from RadProgressBar to RadLinearProgressBar
- **RichTextEditor** — fixed Select Al → Select All typo and Ok → OK casing for OpenHyperlinkErrorOKButtonText localization key
- **TemplatedPicker** — corrected Select value → Select Value casing for two localization keys
- **DataGrid** — added missing Search_StartsWith key and 12 missing AI-related localization keys
- **Scheduler** — added 5 missing AgendaViewDefinition keys, CreateAppointmentDialog_Header, fixed 2 malformed table rows, and added missing delete recurrence dialog keys

## Affected Controls

- None (documentation-only changes — no source code modified)

## Testing Notes

- All changes verified against source code in 	elerik/maui (checked DefaultResources.resx, enum definitions, and class property names)
- No new tests needed for documentation fixes

## Breaking Change

- Breaking change: No

## Release Notes Text

- Not applicable (documentation corrections only)