### PR TITLE
fix: surface explicit DataGrid API members in docs retrieval sections

### DIFF
--- a/controls/datagrid/aggregates/overview.md
+++ b/controls/datagrid/aggregates/overview.md
@@ -22,9 +22,11 @@ The [`PropertyAggregateDescriptor`]({%slug datagrid-property-aggregate-descripto
 
 You can visualize the aggregates inside the:
 
-* [DataGrid Column Footer](#aggregates-in-column-footer)
-* [DataGrid Group Header](#aggregates-in-group-header)
-* [DataGrid Group Footer](#aggregates-in-group-footer)
+* [DataGrid Column Footer](#aggregates-in-column-footer) through the `ShowColumnFooters` property.
+* [DataGrid Group Header](#aggregates-in-group-header) through the `ShowGroupHeaderAggregates` property.
+* [DataGrid Group Footer](#aggregates-in-group-footer) through the `ShowGroupFooters` property.
+
+To calculate and display aggregate results, add aggregate descriptors to the `DataGridColumn.AggregateDescriptors` collection of the target column.
 
 ### Aggregates in Column Footer
 

--- a/controls/datagrid/filtering/overview.md
+++ b/controls/datagrid/filtering/overview.md
@@ -33,6 +33,8 @@ The Telerik DataGrid allows you to apply custom filter control to the DataGrid c
 
 Programmatic filtering is achieved by adding different filter descriptors in the `FilterDescriptors` collection of the control.
 
+The programmatic filtering API uses the `RadDataGrid.FilterDescriptors` collection together with the available filter descriptor types.
+
 >tip Go to the [Programmatic Filtering]({%slug datagrid-programmatic-filtering%}) topic for detailed information about the provided filter descriptors.
 
 >tip For an outline of all DataGrid features review the [.NET MAUI DataGrid Overview]({%slug datagrid-overview%}) article.

--- a/controls/datagrid/overview.md
+++ b/controls/datagrid/overview.md
@@ -42,7 +42,7 @@ The .NET MAUI DataGrid provides a number of features and configuration options r
 
 ## Sorting, Filtering, and Grouping Data
 
-Perform sorting, filtering, and grouping operations on your data by using the convenient API of the control. Apply the [sorting]({%slug datagrid-sorting-overview %}), [filtering]({%slug datagrid-filtering-overview%}), and [grouping]({%slug datagrid-grouping-overview %}) operations per column. You can sort, filter and group through the built-in UI or programmatically using the exposed descriptors.
+Perform sorting, filtering, and grouping operations on your data by using the convenient API of the control. Apply the [sorting]({%slug datagrid-sorting-overview %}), [filtering]({%slug datagrid-filtering-overview%}), and [grouping]({%slug datagrid-grouping-overview %}) operations per column. You can sort, filter and group through the built-in UI or programmatically using the `RadDataGrid.SortDescriptors`, `RadDataGrid.FilterDescriptors`, and `RadDataGrid.GroupDescriptors` collections.
 
 ## Editing
 
@@ -62,7 +62,7 @@ The MAUI DataGrid allows you to represent additional information for the data in
 
 ## Aggregates Support
 
-You can use the exposed API for applying [aggregates functions]({%slug datagrid-aggregates%}). You can use the predefined aggregates functions like `Sum`, `Count`, `Min`, `Max`, `Average`, etc, or implement a custom function. 
+You can use the exposed API for applying [aggregates functions]({%slug datagrid-aggregates%}). Add aggregate descriptors to `DataGridColumn.AggregateDescriptors`, then use the predefined aggregate functions like `Sum`, `Count`, `Min`, `Max`, `Average`, etc, or implement a custom function.
 
 ## Searching As You Type
 
@@ -92,7 +92,7 @@ The DataGrid exposes the `ShowColumnHeaders` (`bool`) property which controls wh
 
 ## Column Footer
 
-The Telerik UI for .NET MAUI DataGrid allows you to display additional information which applies to the columns in a specific row placed at the bottom of the control. This row consists of individual [footer cells]({%slug datagrid-column-footer%}) for each column.
+The Telerik UI for .NET MAUI DataGrid allows you to display additional information which applies to the columns in a specific row placed at the bottom of the control. Set `ShowColumnFooters` to `True` to visualize the row of individual [footer cells]({%slug datagrid-column-footer%}) for each column.
 
 ## Empty Template
 

--- a/controls/datagrid/sorting.md
+++ b/controls/datagrid/sorting.md
@@ -27,8 +27,10 @@ You can also enable or disable the sorting of a specific column and define a val
 
 To sort the DataGrid programmatically, use either of the following approaches:
 
-* Sort by a property with the [`PropertySortDescriptor`](#property-sort-descriptor)
-* Sort by a custom key with the [`DelegateSortDescriptor`](#delegate-sort-descriptor)
+* Sort by a property with the [`PropertySortDescriptor`](#property-sort-descriptor) added to the `RadDataGrid.SortDescriptors` collection.
+* Sort by a custom key with the [`DelegateSortDescriptor`](#delegate-sort-descriptor) added to the `RadDataGrid.SortDescriptors` collection.
+
+Both approaches use the `RadDataGrid.SortDescriptors` collection.
 
 ### Sorting by Properties
 

--- a/controls/datagrid/sorting.md
+++ b/controls/datagrid/sorting.md
@@ -30,8 +30,6 @@ To sort the DataGrid programmatically, use either of the following approaches:
 * Sort by a property with the [`PropertySortDescriptor`](#property-sort-descriptor) added to the `RadDataGrid.SortDescriptors` collection.
 * Sort by a custom key with the [`DelegateSortDescriptor`](#delegate-sort-descriptor) added to the `RadDataGrid.SortDescriptors` collection.
 
-Both approaches use the `RadDataGrid.SortDescriptors` collection.
-
 ### Sorting by Properties
 
 You can sort the data in a DataGrid by pointing a property from the class that defines your objects. To achieve this scenario, use the `PropertySortDescriptor` and set its `PropertyName` property.


### PR DESCRIPTION
## Summary
- make DataGrid aggregate visualization text surface concrete API members early
- add explicit descriptor collection references in sorting/filtering/overview sections
- remove redundant SortDescriptors sentence in sorting docs

## Why
These updates improve shallow retrieval snippets so assistant responses include exact Telerik members instead of only conceptual guidance.