### PR TITLE
Chart: Fix incorrect axis Location property names in axes overview docs

### DIFF
--- a/controls/chart/axes/overview.md
+++ b/controls/chart/axes/overview.md
@@ -123,15 +123,16 @@ The following example demonstrates how to define the major ticks color and set t
 
 ### Location
 
-You can specify the location of the axis with the following properties:
+You can specify the location of the axis with the `Location` property of `CartesianAxis`:
 
-- `HorizontalLocation`&mdash;Specifies the horizontal location of the axis. Applicable for vertical axes.
-- `VerticalLocation`&mdash;Specifies the vertical location of the axis. Applicable for horizontal axes.
+- `Location`&mdash;Specifies which side of the chart the axis appears on. The available values are `Left`, `Right`, `Top`, `Bottom`, and `Unset` (default, uses the chart default side).
 
-The following example demonstrates how to set a vertical location for the axis.
+The following example demonstrates how to move the numerical axis to the right side of the chart.
 
 ```XAML
-	<telerik:CategoricalAxis VerticalLocation="Top"/>
+<telerik:RadCartesianChart.VerticalAxis>
+    <telerik:NumericalAxis Location="Right" />
+</telerik:RadCartesianChart.VerticalAxis>
 ```
 
 ## See Also


### PR DESCRIPTION
- [ ] Tested on affected platforms
- [ ] Public API is discussed with the team

Ready For Test: AB#88951

## Change Summary

- Fixed the "Location" section in `controls/chart/axes/overview.md`: the docs incorrectly documented `HorizontalLocation` and `VerticalLocation` properties, which do not exist in source. The correct property is `Location` (type `AxisLocation`, defined on `CartesianAxis`), with values `Left`, `Right`, `Top`, `Bottom`, and `Unset`.
- Replaced the broken XAML snippet `<telerik:CategoricalAxis VerticalLocation="Top"/>` with a correct example using `NumericalAxis Location="Right"` on `RadCartesianChart.VerticalAxis`.

## Affected Controls

- None (documentation fix only — no control source changes).

## Testing Notes

- Verified against `Source/Compat/Chart/CartesianChart/Axes/CartesianAxis.cs`: `Location` property confirmed, no `HorizontalLocation` or `VerticalLocation` in any axis class.
- The existing XAML snippet would have silently failed at runtime since `VerticalLocation` is not a real property.

## Breaking Change

- Breaking change: No

## Release Notes Text

- Fixes incorrect axis location property names (`HorizontalLocation`/`VerticalLocation`) in the Chart axes documentation; the correct property is `Location`.
