### PR TITLE
PdfViewer: Document breaking change for Document Processing namespace rename in 15.0.0

### DIFF
--- a/controls/pdfviewer/fonts.md
+++ b/controls/pdfviewer/fonts.md
@@ -75,7 +75,7 @@ private static byte[] ReadAllBytes(Stream input)
 Assembly assembly = typeof(MainPage).Assembly;
 Stream stream = assembly.GetManifestResourceStream("SampleApp.Resources.SampleFont.ttf");
 var fontData = ReadAllBytes(stream);
-Telerik.Windows.Documents.Fixed.Model.Fonts.FontsRepository.RegisterFont(
+Telerik.Documents.Fixed.Model.Fonts.FontsRepository.RegisterFont(
 	new FontFamily("Verdana"), FontStyles.Normal, FontWeights.Normal, fontData);
 ```
 

--- a/controls/pdfviewer/password.md
+++ b/controls/pdfviewer/password.md
@@ -24,7 +24,7 @@ The following example demonstrates how to use the `SourcePasswordNeeded` event:
 The next code snippet represents the event handler:
 
 ```C#
-private void pdfViewer_SourcePasswordNeeded(object sender, Telerik.Windows.Documents.Fixed.FormatProviders.Pdf.Import.PasswordNeededEventArgs e)
+private void pdfViewer_SourcePasswordNeeded(object sender, Telerik.Documents.Fixed.FormatProviders.Pdf.Import.PasswordNeededEventArgs e)
 {
     e.Password = "my_user_password_here";
 }

--- a/controls/pdfviewer/search/configuration.md
+++ b/controls/pdfviewer/search/configuration.md
@@ -18,7 +18,7 @@ Through the `Text` property of the `SearchSettings` you can retrieve or explicit
 
 ## Searching Options
 
-Define the search criteria by using the `SearchOptions` (of type `Telerik.Windows.Documents.Fixed.Search.TextSearchOptions`) and use it to define some search criteria as listed below:
+Define the search criteria by using the `SearchOptions` (of type `Telerik.Documents.Fixed.Search.TextSearchOptions`) and use it to define some search criteria as listed below:
 
 * `UseRegularExpression`&mdash;Specifies whether a regular expression is used for searching.
 * `CaseSensitive`&mdash;Indicates whether the search can be case sensitive.
@@ -50,7 +50,7 @@ You can get the search results by using the following properties:
 * `TextSearchResult` (property of the `SearchSettings`)&mdash;Retrieves the current search result. It contains the results that match the search as well as the main result. The main result is highlighted differently from the other search results and is used for navigation purposes, so that the user can navigate to previous and next results and keep track.
 The `TextSearchResult` exposes the following properties:
 	* static `TextSearchResult.NotFound` property&mdash;Is Returned when the search criteria has no results;
-	* `SearchResults`&mdash;Read-only collection of type `Telerik.Windows.Documents.Fixed.Search.SearchResult` which contains all the search results.
+	* `SearchResults`&mdash;Read-only collection of type `Telerik.Documents.Fixed.Search.SearchResult` which contains all the search results.
 	* `MainSearchResult`&mdash;A reference to the search result that are the main result.
 
 ## Search Results Highlight Colors
@@ -65,7 +65,7 @@ Add the folowing namespaces:
 
 ```XAML
 xmlns:telerik="http://schemas.telerik.com/2022/xaml/maui"
-xmlns:telerikTextSearch="clr-namespace:Telerik.Windows.Documents.Fixed.Search;assembly=Telerik.Documents.Fixed"
+xmlns:telerikTextSearch="clr-namespace:Telerik.Documents.Fixed.Search;assembly=Telerik.Documents.Fixed"
 ```
 
 ## Methods

--- a/knowledge-base/display-semi-transparent-watermarks-maui-pdfviewer.md
+++ b/knowledge-base/display-semi-transparent-watermarks-maui-pdfviewer.md
@@ -52,7 +52,7 @@ private static void UpdateWatermarkTransparency(RadFixedPage fixedPage)
 {
     foreach (var contentElement in fixedPage.Content)
     {
-        if (contentElement is Telerik.Windows.Documents.Fixed.Model.Text.TextFragment textBlock)
+        if (contentElement is Telerik.Documents.Fixed.Model.Text.TextFragment textBlock)
         {
             if (textBlock.Text.Contains("Watermark text!"))
             {

--- a/knowledge-base/export-datagrid-to-pdf-net-maui.md
+++ b/knowledge-base/export-datagrid-to-pdf-net-maui.md
@@ -190,7 +190,7 @@ public class ExportToPdfViewModel : NotifyPropertyChangedBase
 		RgbColor bordersColor = new RgbColor(205, 205, 205);
 		RgbColor alternatingRowColor = new RgbColor(243, 243, 243);
 
-		Telerik.Windows.Documents.Fixed.Model.Editing.Border border = new Telerik.Windows.Documents.Fixed.Model.Editing.Border(1, Telerik.Windows.Documents.Fixed.Model.Editing.BorderStyle.Single, bordersColor);
+		Telerik.Documents.Fixed.Model.Editing.Border border = new Telerik.Documents.Fixed.Model.Editing.Border(1, Telerik.Documents.Fixed.Model.Editing.BorderStyle.Single, bordersColor);
 
 		Table table = new Table();
 		table.Borders = new TableBorders(border);
@@ -209,7 +209,7 @@ public class ExportToPdfViewModel : NotifyPropertyChangedBase
 
 			Block block = headerCell.Blocks.AddBlock();
 			block.GraphicProperties.FillColor = RgbColors.White;
-			block.HorizontalAlignment = Telerik.Windows.Documents.Fixed.Model.Editing.Flow.HorizontalAlignment.Center;
+			block.HorizontalAlignment = Telerik.Documents.Fixed.Model.Editing.Flow.HorizontalAlignment.Center;
 			block.InsertText(column);
 	
 		}
@@ -237,7 +237,7 @@ public class ExportToPdfViewModel : NotifyPropertyChangedBase
 			cell.Background = rowColor;
 
 			block = cell.Blocks.AddBlock();
-			block.HorizontalAlignment = Telerik.Windows.Documents.Fixed.Model.Editing.Flow.HorizontalAlignment.Right;
+			block.HorizontalAlignment = Telerik.Documents.Fixed.Model.Editing.Flow.HorizontalAlignment.Right;
 			block.InsertText(string.Format("{0:P0}", (double)course.Progress / 100));
 		}
 

--- a/knowledge-base/save-pdf-files-mobile-desktop.md
+++ b/knowledge-base/save-pdf-files-mobile-desktop.md
@@ -77,7 +77,7 @@ public class ViewModel
 
 		using (Stream output = File.OpenWrite(filePath))
 		{
-			new Telerik.Windows.Documents.Fixed.FormatProviders.Pdf.PdfFormatProvider().Export(this.Document, output);
+			new Telerik.Documents.Fixed.FormatProviders.Pdf.PdfFormatProvider().Export(this.Document, output);
 
 			Application.Current.MainPage.DisplayAlert("Document is saved to local application data: ", filePath, "OK");
 		}

--- a/upgrade/breaking-changes/14-0-0.md
+++ b/upgrade/breaking-changes/14-0-0.md
@@ -4,7 +4,6 @@ description: Handle the changes in the 14.0.0 release version of the Telerik UI 
 page_title: Breaking Changes in 14.0.0
 slug: changes-in-14-0-0
 position: 4
-tag: new
 ---
 
 # Breaking Changes in Version 14.0.0

--- a/upgrade/breaking-changes/15-0-0.md
+++ b/upgrade/breaking-changes/15-0-0.md
@@ -1,0 +1,71 @@
+---
+title: 15.0.0
+description: Handle the changes in the 15.0.0 release version of the Telerik UI for .NET MAUI components.
+page_title: Breaking Changes in 15.0.0
+slug: changes-in-15-0-0
+position: 3
+tag: new
+---
+
+# Breaking Changes in Version 15.0.0
+
+This article lists the breaking changes introduced with the Telerik UI for .NET MAUI 15.0.0 release version.
+
+## Document Processing Libraries
+
+All namespaces of the Telerik Document Processing Libraries are renamed from `Telerik.Windows.Documents.*` to `Telerik.Documents.*`. The assembly names are not changed, so you don't have to update any package or assembly references. However, you must update every `using` directive, fully qualified type name, and XAML `clr-namespace` mapping that points to the old namespaces.
+
+This change affects the [PdfViewer]({%slug pdfviewer-overview%}) and [RichTextEditor]({%slug richtexteditor-overview%}) controls, as well as the [PdfProcessing]({%slug pdfprocessing-overview%}), [WordsProcessing]({%slug wordsprocessing-overview%}), [SpreadProcessing]({%slug spreadprocessing-overview%}), and [SpreadStreamProcessing]({%slug spreadstreamprocessing-overview%}) libraries.
+
+The following table lists the renamed namespaces:
+
+| Old Namespace | New Namespace |
+| ------------- | ------------- |
+| `Telerik.Windows.Documents.Common.FormatProviders` | `Telerik.Documents.Common.FormatProviders` |
+| `Telerik.Windows.Documents.Core.*` | `Telerik.Documents.Core.*` |
+| `Telerik.Windows.Documents.Extensibility` | `Telerik.Documents.Extensibility` |
+| `Telerik.Windows.Documents.Fixed.*` | `Telerik.Documents.Fixed.*` |
+| `Telerik.Windows.Documents.Flow.*` | `Telerik.Documents.Flow.*` |
+| `Telerik.Windows.Documents.Spreadsheet.*` | `Telerik.Documents.Spreadsheet.*` |
+| `Telerik.Windows.Documents.Primitives` | `Telerik.Documents.Primitives` |
+| `Telerik.Windows.Documents.Utilities` | `Telerik.Documents.Utilities` |
+
+For example, update the `using` directives in your C# code:
+
+```C#
+// Old
+using Telerik.Windows.Documents.Fixed.Model;
+using Telerik.Windows.Documents.Fixed.Search;
+
+// New
+using Telerik.Documents.Fixed.Model;
+using Telerik.Documents.Fixed.Search;
+```
+
+And update the `clr-namespace` mappings in your XAML:
+
+```XAML
+<!-- Old -->
+xmlns:telerikTextSearch="clr-namespace:Telerik.Windows.Documents.Fixed.Search;assembly=Telerik.Documents.Fixed"
+
+<!-- New -->
+xmlns:telerikTextSearch="clr-namespace:Telerik.Documents.Fixed.Search;assembly=Telerik.Documents.Fixed"
+```
+
+## PdfViewer
+
+The names and the signatures of the PdfViewer members are not changed, but the following members expose types from the Document Processing Libraries, so the namespaces of these types change as described in the [Document Processing Libraries](#document-processing-libraries) section:
+
+| Member | Affected Type |
+| ------ | ------------- |
+| `RadPdfViewer.Document` | `RadFixedDocument` |
+| `RadPdfViewer.SourcePasswordNeeded` and `DocumentSource.PasswordNeeded` | `PasswordNeededEventArgs` |
+| `PageElementsLoadedEventArgs.Page` | `RadFixedPage` |
+| `LinkAnnotationTappedEventArgs.LinkAnnotation` | `Link` |
+| `FixedDocumentSource` constructor and implicit operators, `DocumentSource` implicit operator | `RadFixedDocument` |
+| `PdfViewerSearchSettings.SearchOptions` and `PdfViewerSearchSettings.SearchAsync` | `TextSearchOptions` |
+| `PdfViewerTextSearchResult.SearchResults` and `PdfViewerTextSearchResult.MainSearchResult` | `SearchResult` |
+| `PdfViewerSearchContext` public fields and constructors | `RadFixedDocument`, `TextSearchOptions` |
+| `PdfViewerTextSearchWorker` overridable members | `RadFixedDocument`, `TextSearchOptions`, `SearchResult` |
+
+> Applications that are compiled against an earlier version of the Document Processing Libraries must be rebuilt against the new version.

--- a/upgrade/breaking-changes/15-0-0.md
+++ b/upgrade/breaking-changes/15-0-0.md
@@ -15,7 +15,7 @@ This article lists the breaking changes introduced with the Telerik UI for .NET 
 
 All namespaces of the Telerik Document Processing Libraries are renamed from `Telerik.Windows.Documents.*` to `Telerik.Documents.*`. The assembly names are not changed, so you don't have to update any package or assembly references. However, you must update every `using` directive, fully qualified type name, and XAML `clr-namespace` mapping that points to the old namespaces.
 
-This change affects the [PdfViewer]({%slug pdfviewer-overview%}) and [RichTextEditor]({%slug richtexteditor-overview%}) controls, as well as the [PdfProcessing]({%slug pdfprocessing-overview%}), [WordsProcessing]({%slug wordsprocessing-overview%}), [SpreadProcessing]({%slug spreadprocessing-overview%}), and [SpreadStreamProcessing]({%slug spreadstreamprocessing-overview%}) libraries.
+This change affects the [PdfViewer]({%slug pdfviewer-overview%}) control, as well as the [PdfProcessing]({%slug pdfprocessing-overview%}), [WordsProcessing]({%slug wordsprocessing-overview%}), and [SpreadProcessing]({%slug spreadprocessing-overview%}) libraries. The [SpreadStreamProcessing]({%slug spreadstreamprocessing-overview%}) library is not affected because it already uses the `Telerik.Documents.SpreadsheetStreaming` namespaces.
 
 The following table lists the renamed namespaces:
 


### PR DESCRIPTION
## Change Summary

- Adds a new `upgrade/breaking-changes/15-0-0.md` article documenting the rename of all Telerik Document Processing namespaces from `Telerik.Windows.Documents.*` to `Telerik.Documents.*`, introduced by the DPL update to `2026.2.724-preview`.
- The article includes the full old-to-new namespace mapping table, before/after C# `using` and XAML `clr-namespace` examples, and a table of the PdfViewer public members whose exposed DPL types moved.
- Clarifies that assembly names are unchanged, so no package or assembly references need updating, and that pre-compiled applications must be rebuilt.
- Updates the 10 remaining stale `Telerik.Windows.Documents.*` references across the PdfViewer articles and the knowledge base so all code snippets compile against the new namespaces.
- Removes `tag: new` from `14-0-0.md` so only the newest breaking-changes article carries it, matching the convention used by 13-0-0 and earlier.

## Affected Controls

- None (documentation-only change). The documented change affects the `RadPdfViewer` and `RadRichTextEditor` public API surface, but no control source code is modified in this PR.

## Testing Notes

- No automated tests apply to this repository.
- Every target namespace was verified by reading type metadata directly from the `Telerik.Documents.Fixed.dll` and `Telerik.Documents.Core.dll` assemblies of the `2026.2.724-preview` package rather than being inferred from the rename pattern. This confirmed, for example, that `FontsRepository` resolves to `Telerik.Documents.Fixed.Model.Fonts`.
- `git grep "Telerik.Windows"` returns no results across the repository after the change.
- All six cross-article slugs referenced by the new article (`pdfviewer-overview`, `richtexteditor-overview`, `pdfprocessing-overview`, `wordsprocessing-overview`, `spreadprocessing-overview`, `spreadstreamprocessing-overview`) were verified to exist.
- Reviewers should confirm the target release version is 15.0.0 and adjust the file name, slug, and `position` if the change ships in a different version.

## Breaking Change

- Breaking change: Yes
- All Document Processing namespaces are renamed from `Telerik.Windows.Documents.*` to `Telerik.Documents.*`. Assembly names are unchanged.
- Consumers must update every `using` directive, fully qualified type name, and XAML `clr-namespace` mapping that references the old namespaces.
- Because the PdfViewer public API exposes DPL types directly (`RadPdfViewer.Document`, `PasswordNeededEventArgs`, `RadFixedPage`, `TextSearchOptions`, `SearchResult`, and others), the change is source breaking for consumer C# and XAML code and binary breaking for pre-compiled assemblies, which must be rebuilt.
- This PR only documents the change; the rename itself originates in the Document Processing Libraries.

## Release Notes Text

- The Document Processing namespaces are renamed from `Telerik.Windows.Documents.*` to `Telerik.Documents.*`, which requires updating the `using` directives and XAML namespace mappings in applications that use `RadPdfViewer`, `RadRichTextEditor`, or the document processing libraries.

